### PR TITLE
使用渐进顺序改进部分歌曲匹配翻译逻辑，使用ISRC进行不同地区曲库比对，扩大原地区原名及翻译匹配命中率

### DIFF
--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/common/lyric/LyricMetadataKeys.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/common/lyric/LyricMetadataKeys.kt
@@ -2,9 +2,11 @@ package com.juren233.hyperlyricsenhanced.common.lyric
 
 object LyricMetadataKeys {
     const val APPLE_CATALOG_GENRE = "appleCatalogGenre"
+    const val APPLE_ALBUM = "appleAlbum"
     const val APPLE_PRONUNCIATION_LANGUAGES = "applePronunciationLanguages"
     const val APPLE_ORIGINAL_TITLE = "appleOriginalTitle"
     const val APPLE_ORIGINAL_ARTIST = "appleOriginalArtist"
+    const val APPLE_ORIGINAL_ALBUM = "appleOriginalAlbum"
     const val APPLE_ORIGINAL_METADATA_RESOLVED = "appleOriginalMetadataResolved"
     const val ONLINE_TRANSLATION_SOURCE = "onlineTranslationSource"
     const val ONLINE_PRONUNCIATION_SOURCE = "onlinePronunciationSource"

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/lyric/LyricProviderImpl.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/lyric/LyricProviderImpl.kt
@@ -29,7 +29,8 @@ class LyricProviderImpl(private val context: Context) : ILyricProvider {
                     params.packageName,
                     params.title,
                     params.artist,
-                    params.duration
+                    params.duration,
+                    album = params.album,
                 )
 
                 // 3. 搜索成功，存入缓存

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/online/OnlineLyricTargeter.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/online/OnlineLyricTargeter.kt
@@ -12,11 +12,15 @@ import com.juren233.hyperlyricsenhanced.online.utils.ChineseUtils
 import com.juren233.hyperlyricsenhanced.utils.LogManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withTimeoutOrNull
+import java.text.Normalizer
 import kotlin.math.abs
 
 object OnlineLyricTargeter {
     private const val TIMEOUT_MS = 5000L
-    private const val PASS_SCORE = 85
+    private const val TOTAL_TIMEOUT_MS = 15_000L
+    private const val PASS_SCORE = 80
+    private const val SEARCH_PAGE_SIZE = 50
+    private const val MAX_LYRIC_CANDIDATES_PER_QUERY = 5
 
     suspend fun fetchBestLyric(
         context: Context,
@@ -24,13 +28,16 @@ object OnlineLyricTargeter {
         title: String, 
         artist: String, 
         durationMs: Long,
+        album: String = "",
         originalTitle: String? = null,
         originalArtist: String? = null,
+        originalAlbum: String? = null,
         preferOriginalMetadata: Boolean = false,
         preferredSource: Source? = null,
         requireTranslation: Boolean = false,
-        fallbackToOtherSources: Boolean = true
-    ): List<LrcLine>? {
+        fallbackToOtherSources: Boolean = true,
+        diagnostic: ((String) -> Unit)? = null,
+    ): List<LrcLine>? = withTimeoutOrNull(TOTAL_TIMEOUT_MS) {
         val ne = LyricApiProvider.getNeSource(context)
         val qm = LyricApiProvider.qmSource
         val sourcesByType = mapOf(Source.NE to ne, Source.QM to qm)
@@ -42,20 +49,23 @@ object OnlineLyricTargeter {
 
         val resolvedTitle = originalTitle?.takeIf { it.isNotBlank() } ?: title
         val resolvedArtist = originalArtist?.takeIf { it.isNotBlank() } ?: artist
+        val resolvedAlbum = originalAlbum?.takeIf { it.isNotBlank() } ?: album
         val hasDistinctOriginalMetadata = shouldRetryWithOriginalMetadata(
-            title,
-            artist,
-            originalTitle,
-            originalArtist,
+            title = title,
+            artist = artist,
+            originalTitle = originalTitle,
+            originalArtist = originalArtist,
+            album = album,
+            originalAlbum = originalAlbum,
         )
         val searches = resolveMetadataSearchOrder(
             preferOriginalMetadata = preferOriginalMetadata,
             hasDistinctOriginalMetadata = hasDistinctOriginalMetadata,
         ).map { useOriginalMetadata ->
             if (useOriginalMetadata) {
-                SearchMetadata(resolvedTitle, resolvedArtist, "Apple 内部原名")
+                SearchMetadata(resolvedTitle, resolvedArtist, resolvedAlbum, "Apple 内部原名")
             } else {
-                SearchMetadata(title, artist, "当前元数据")
+                SearchMetadata(title, artist, album, "当前元数据")
             }
         }
         searches.forEachIndexed { index, metadata ->
@@ -70,12 +80,14 @@ object OnlineLyricTargeter {
                 sources = sources,
                 title = metadata.title,
                 artist = metadata.artist,
+                album = metadata.album,
                 durationMs = durationMs,
                 requireTranslation = requireTranslation,
                 metadataLabel = metadata.label,
-            )?.let { return it }
+                diagnostic = diagnostic,
+            )?.let { return@withTimeoutOrNull it }
         }
-        return null
+        null
     }
 
     private suspend fun searchSources(
@@ -83,106 +95,162 @@ object OnlineLyricTargeter {
         sources: List<SearchSource>,
         title: String,
         artist: String,
+        album: String,
         durationMs: Long,
         requireTranslation: Boolean,
-        metadataLabel: String
+        metadataLabel: String,
+        diagnostic: ((String) -> Unit)?,
     ): List<LrcLine>? {
-
-        val keyword = "$title $artist"
-        LogManager.d(
-            "OnlineTargeter",
-            "正在搜索: 类型=$metadataLabel, 关键词=\"$keyword\", " +
-                "源顺序=${sources.joinToString { it.javaClass.simpleName }}"
-        )
 
         val cleanLocalTitle = cleanString(context, title)
         val localArtists = splitArtists(artist).map { cleanString(context, it) }
+        val cleanLocalAlbum = cleanString(context, album)
         val featureKeywords = listOf("live", "remastered", "翻唱", "cover")
         val localFeatures = featureKeywords.filter { title.lowercase().contains(it) }
-        
+        val keywords = resolveSearchKeywords(title, artist, album)
         var bestScore = -1
 
         for (source in sources) {
-            val results = withTimeoutOrNull(TIMEOUT_MS) {
-                try {
-                    source.search(keyword, 1, "/", 20)
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    LogManager.w("OnlineTargeter", "搜索异常: 源=${source.javaClass.simpleName}, ${e.message}")
-                    null
-                }
-            }
-            if (results.isNullOrEmpty()) {
-                LogManager.d("OnlineTargeter", "搜索结果为空: 源=${source.javaClass.simpleName}")
-                continue
-            }
-            LogManager.d("OnlineTargeter", "搜索结果: 源=${source.javaClass.simpleName}, 数量=${results.size}")
-
-            var localBestScore = -1
-            var bestSong: SongSearchResult? = null
-
-            for (song in results) {
-                val score = calculateScore(
-                    context,
-                    song,
-                    cleanLocalTitle,
-                    localArtists,
-                    localFeatures,
-                    durationMs,
+            val attemptedSongIds = mutableSetOf<String>()
+            for (keyword in keywords) {
+                LogManager.d(
+                    "OnlineTargeter",
+                    "正在搜索: 类型=$metadataLabel, 关键词=\"$keyword\", " +
+                        "源=${source.javaClass.simpleName}"
                 )
-                if (score > localBestScore) {
-                    localBestScore = score
-                    bestSong = song
-                }
-            }
-
-            if (localBestScore > bestScore) bestScore = localBestScore
-            LogManager.d(
-                "OnlineTargeter",
-                "评分: \"${bestSong?.title}\" - \"${bestSong?.artist}\", " +
-                    "得分=$localBestScore, 阈值=$PASS_SCORE, 通过=${localBestScore >= PASS_SCORE}"
-            )
-
-            if (localBestScore >= PASS_SCORE && bestSong != null) {
-                val lyricsResult = withTimeoutOrNull(TIMEOUT_MS) {
+                val results = withTimeoutOrNull(TIMEOUT_MS) {
                     try {
-                        source.getLyrics(bestSong)
+                        source.search(keyword, 1, "/", SEARCH_PAGE_SIZE)
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
-                        LogManager.w("OnlineTargeter", "获取歌词异常: 源=${source.javaClass.simpleName}, ${e.message}")
+                        LogManager.w(
+                            "OnlineTargeter",
+                            "搜索异常: 源=${source.javaClass.simpleName}, ${e.message}"
+                        )
                         null
                     }
                 }
-                
-                if (lyricsResult != null && (lyricsResult.original.isNotEmpty() || !lyricsResult.translated.isNullOrEmpty())) {
-                    val list = toLrcLines(lyricsResult)
-                    if (list.isNotEmpty()) {
-                        if (requireTranslation && list.none {
-                                OnlineTranslationContentPolicy.isMeaningful(it.translation)
-                            }
-                        ) {
-                            LogManager.d(
+                if (results.isNullOrEmpty()) {
+                    LogManager.d(
+                        "OnlineTargeter",
+                        "搜索结果为空: 源=${source.javaClass.simpleName}, 关键词=\"$keyword\""
+                    )
+                    continue
+                }
+                LogManager.d(
+                    "OnlineTargeter",
+                    "搜索结果: 源=${source.javaClass.simpleName}, " +
+                        "关键词=\"$keyword\", 数量=${results.size}"
+                )
+
+                val candidates = results
+                    .map { song ->
+                        song to calculateScore(
+                            context,
+                            song,
+                            cleanLocalTitle,
+                            localArtists,
+                            cleanLocalAlbum,
+                            localFeatures,
+                            durationMs,
+                        )
+                    }
+                    .sortedByDescending { (_, score) -> score.total }
+                val localBest = candidates.firstOrNull()
+                val localBestScore = localBest?.second?.total ?: -1
+                if (localBestScore > bestScore) bestScore = localBestScore
+                LogManager.d(
+                    "OnlineTargeter",
+                    "评分: \"${localBest?.first?.title}\" - \"${localBest?.first?.artist}\" / " +
+                        "\"${localBest?.first?.album}\", " +
+                        "得分=$localBestScore, 阈值=$PASS_SCORE, " +
+                        "标题=${localBest?.second?.titleMatched}, " +
+                        "歌手=${localBest?.second?.artistMatched}, " +
+                        "专辑=${localBest?.second?.albumMatched}, " +
+                        "通过=${localBest?.second?.isEligible == true}, 关键词=\"$keyword\""
+                )
+                diagnostic?.invoke(
+                    "在线候选联合评分: metadata=$metadataLabel, " +
+                        "query=\"$keyword\", source=${source.javaClass.simpleName}, " +
+                        "candidateTitle=${localBest?.first?.title}, " +
+                        "candidateArtist=${localBest?.first?.artist}, " +
+                        "candidateAlbum=${localBest?.first?.album}, score=$localBestScore, " +
+                        "titleMatched=${localBest?.second?.titleMatched}, " +
+                        "artistMatched=${localBest?.second?.artistMatched}, " +
+                        "albumMatched=${localBest?.second?.albumMatched}, " +
+                        "eligible=${localBest?.second?.isEligible == true}"
+                )
+
+                val eligibleCandidates = candidates
+                    .asSequence()
+                    .filter { (_, score) -> score.isEligible }
+                    .filter { (song, _) -> attemptedSongIds.add(song.id) }
+                    .take(MAX_LYRIC_CANDIDATES_PER_QUERY)
+                    .toList()
+                for ((candidate, candidateMatch) in eligibleCandidates) {
+                    val lyricsResult = withTimeoutOrNull(TIMEOUT_MS) {
+                        try {
+                            source.getLyrics(candidate)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            LogManager.w(
                                 "OnlineTargeter",
-                                "当前源无可用翻译，继续尝试后续源: " +
-                                    "源=${source.javaClass.simpleName}"
+                                "获取歌词异常: 源=${source.javaClass.simpleName}, " +
+                                    "id=${candidate.id}, ${e.message}"
                             )
-                            continue
+                            null
                         }
+                    }
+
+                    if (lyricsResult == null ||
+                        (lyricsResult.original.isEmpty() && lyricsResult.translated.isNullOrEmpty())
+                    ) {
                         LogManager.d(
                             "OnlineTargeter",
-                            "歌词命中: 类型=$metadataLabel, 源=${source.javaClass.simpleName}, " +
-                                "得分=$bestScore, 行数=${list.size}"
+                            "候选无可用歌词，尝试下一条: 源=${source.javaClass.simpleName}, " +
+                                "id=${candidate.id}, score=${candidateMatch.total}"
                         )
-                        return list
+                        continue
                     }
+
+                    val list = toLrcLines(lyricsResult)
+                    if (list.isEmpty()) continue
+                    if (requireTranslation && list.none {
+                            OnlineTranslationContentPolicy.isMeaningful(it.translation)
+                        }
+                    ) {
+                        LogManager.d(
+                            "OnlineTargeter",
+                            "当前候选无可用翻译，尝试下一条: " +
+                                "源=${source.javaClass.simpleName}, id=${candidate.id}"
+                        )
+                        continue
+                    }
+                    LogManager.d(
+                        "OnlineTargeter",
+                        "歌词命中: 类型=$metadataLabel, 源=${source.javaClass.simpleName}, " +
+                            "得分=${candidateMatch.total}, 行数=${list.size}, 关键词=\"$keyword\""
+                    )
+                    diagnostic?.invoke(
+                        "在线候选联合命中: metadata=$metadataLabel, " +
+                            "source=${source.javaClass.simpleName}, title=${candidate.title}, " +
+                            "artist=${candidate.artist}, album=${candidate.album}, " +
+                            "score=${candidateMatch.total}"
+                    )
+                    return list
                 }
             }
         }
         LogManager.d(
             "OnlineTargeter",
-            "歌词未命中: 类型=$metadataLabel, 最佳得分=$bestScore < 阈值 $PASS_SCORE"
+            "歌词未命中: 类型=$metadataLabel, 最佳得分=$bestScore, 阈值=$PASS_SCORE, " +
+                "要求=标题匹配且歌手或专辑至少一项匹配"
+        )
+        diagnostic?.invoke(
+            "在线候选联合未命中: metadata=$metadataLabel, title=$title, artist=$artist, " +
+                "album=$album, bestScore=$bestScore, requirement=title+(artist|album)"
         )
         return null
     }
@@ -191,13 +259,17 @@ object OnlineLyricTargeter {
         title: String,
         artist: String,
         originalTitle: String?,
-        originalArtist: String?
+        originalArtist: String?,
+        album: String = "",
+        originalAlbum: String? = null,
     ): Boolean {
         val resolvedTitle = originalTitle?.trim().orEmpty()
         val resolvedArtist = originalArtist?.trim().orEmpty()
-        if (resolvedTitle.isEmpty() && resolvedArtist.isEmpty()) return false
+        val resolvedAlbum = originalAlbum?.trim().orEmpty()
+        if (resolvedTitle.isEmpty() && resolvedArtist.isEmpty() && resolvedAlbum.isEmpty()) return false
         return !resolvedTitle.equals(title.trim(), ignoreCase = true) ||
-            !resolvedArtist.equals(artist.trim(), ignoreCase = true)
+            !resolvedArtist.equals(artist.trim(), ignoreCase = true) ||
+            !resolvedAlbum.equals(album.trim(), ignoreCase = true)
     }
 
     internal fun resolveMetadataSearchOrder(
@@ -260,9 +332,10 @@ object OnlineLyricTargeter {
         song: SongSearchResult,
         cleanLocalTitle: String,
         localArtists: List<String>,
+        cleanLocalAlbum: String,
         localFeatures: List<String>,
         localDurationMs: Long
-    ): Int {
+    ): CandidateMatch {
         var score = 0
 
         if (localDurationMs > 0 && song.duration > 0) {
@@ -271,16 +344,24 @@ object OnlineLyricTargeter {
 
         val cleanSongTitle = cleanString(context, song.title)
 
-        if (cleanLocalTitle == cleanSongTitle || cleanSongTitle.contains(cleanLocalTitle) || cleanLocalTitle.contains(cleanSongTitle)) {
+        val titleMatched = stringsMatch(cleanLocalTitle, cleanSongTitle)
+        if (titleMatched) {
             score += 50
         }
 
         val songArtists = splitArtists(song.artist).map { cleanString(context, it) }
         
-        val hasCommonArtist = localArtists.any { lArtist -> songArtists.any { sArtist -> lArtist == sArtist || sArtist.contains(lArtist) || lArtist.contains(sArtist) } }
-        if (hasCommonArtist) {
+        val artistMatched = localArtists.any { localArtist ->
+            songArtists.any { songArtist -> stringsMatch(localArtist, songArtist) }
+        }
+        if (artistMatched) {
             score += 30
         }
+
+        val cleanSongAlbum = cleanString(context, song.album)
+        val albumMatched = cleanLocalAlbum.isNotEmpty() && cleanSongAlbum.isNotEmpty() &&
+            stringsMatch(cleanLocalAlbum, cleanSongAlbum)
+        if (albumMatched) score += 30
 
         val songFeatures = listOf("live", "remastered", "翻唱", "cover").filter { song.title.lowercase().contains(it) }
         
@@ -291,13 +372,24 @@ object OnlineLyricTargeter {
             }
         }
 
-        return score
+        return CandidateMatch(
+            total = score,
+            titleMatched = titleMatched,
+            artistMatched = artistMatched,
+            albumMatched = albumMatched,
+        )
     }
 
     private fun cleanString(context: Context, input: String): String {
-        val cleaned = input.replace(Regex("\\(.*?\\)|\\[.*?]|\\{.*?\\}"), "").trim().lowercase()
+        val cleaned = normalizeWidth(input)
+            .replace(BRACKETED_SEGMENT_REGEX, "")
+            .trim()
+            .lowercase()
         return compactWhitespace(ChineseUtils.toSimplified(context, cleaned))
     }
+
+    internal fun normalizeWidth(value: String): String =
+        Normalizer.normalize(value, Normalizer.Form.NFKC)
 
     internal fun durationScore(localDurationMs: Long, remoteDurationMs: Long): Int {
         val diffMs = abs(localDurationMs - remoteDurationMs)
@@ -310,12 +402,74 @@ object OnlineLyricTargeter {
 
     internal fun compactWhitespace(value: String): String = value.replace(Regex("\\s+"), "")
 
+    /**
+     * Search APIs are much less tolerant of voice-actor credits than the local scorer. Keep the
+     * precise query first, then progressively reduce it while the scorer remains authoritative.
+     */
+    internal fun resolveSearchKeywords(
+        title: String,
+        artist: String,
+        album: String = "",
+    ): List<String> {
+        val cleanTitle = title.trim()
+        if (cleanTitle.isEmpty()) return emptyList()
+        val cleanArtist = artist.trim()
+        val cleanAlbum = album.trim()
+        val albumPrecise = listOf(cleanTitle, cleanArtist, cleanAlbum)
+            .filter(String::isNotEmpty)
+            .joinToString(" ")
+        val artistPrecise = listOf(cleanTitle, cleanArtist)
+            .filter(String::isNotEmpty)
+            .joinToString(" ")
+        val artistQueries = splitArtists(artist)
+            .asSequence()
+            .map { value ->
+                value.replace(BRACKETED_SEGMENT_REGEX, " ")
+                    .replace(Regex("(?i)\\b(?:cv|feat|ft)\\.?\\s*[:.]?"), " ")
+                    .replace(Regex("\\s+"), " ")
+                    .trim()
+            }
+            .filter(String::isNotEmpty)
+            .distinctBy(String::lowercase)
+            .take(3)
+            .map { "$cleanTitle $it" }
+            .toList()
+        return buildList {
+            if (cleanAlbum.isNotEmpty()) add(albumPrecise)
+            if (artistPrecise.isNotEmpty()) add(artistPrecise)
+            addAll(artistQueries)
+            if (cleanAlbum.isNotEmpty()) add("$cleanTitle $cleanAlbum")
+            add(cleanTitle)
+        }.distinctBy(String::lowercase)
+    }
+
+    private fun stringsMatch(first: String, second: String): Boolean =
+        first.isNotEmpty() && second.isNotEmpty() &&
+            (first == second || first.contains(second) || second.contains(first))
+
     private fun splitArtists(value: String): List<String> =
         value.split("&", ",", "，", "、", "/", "／")
+
+    // Escape closing delimiters explicitly. Android's ICU regex rejects the Java-tolerated
+    // forms `[.*?]` / `{.*?}` with PatternSyntaxException before any search request is sent.
+    private val BRACKETED_SEGMENT_REGEX = Regex(
+        "\\([^)]*\\)|\\[[^\\]]*\\]|\\{[^}]*\\}",
+    )
+
+    internal data class CandidateMatch(
+        val total: Int,
+        val titleMatched: Boolean,
+        val artistMatched: Boolean,
+        val albumMatched: Boolean,
+    ) {
+        val isEligible: Boolean
+            get() = total >= PASS_SCORE && titleMatched && (artistMatched || albumMatched)
+    }
 
     private data class SearchMetadata(
         val title: String,
         val artist: String,
+        val album: String,
         val label: String,
     )
 

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/online/OnlineLyricTargeter.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/online/OnlineLyricTargeter.kt
@@ -19,6 +19,13 @@ object OnlineLyricTargeter {
     private const val TIMEOUT_MS = 5000L
     private const val TOTAL_TIMEOUT_MS = 15_000L
     private const val PASS_SCORE = 80
+    private const val TITLE_SCORE = 50
+    private const val ARTIST_SCORE = 30
+    private const val ALBUM_SCORE = 30
+    private const val FEATURE_SCORE = 20
+    private const val DURATION_CLOSE_SCORE = 15
+    private const val DURATION_DRIFT_SCORE = 10
+    private const val DURATION_MISMATCH_SCORE = -30
     private const val SEARCH_PAGE_SIZE = 50
     private const val MAX_LYRIC_CANDIDATES_PER_QUERY = 5
 
@@ -176,6 +183,8 @@ object OnlineLyricTargeter {
                         "candidateTitle=${localBest?.first?.title}, " +
                         "candidateArtist=${localBest?.first?.artist}, " +
                         "candidateAlbum=${localBest?.first?.album}, score=$localBestScore, " +
+                        "localAlbumKey=$cleanLocalAlbum, " +
+                        "candidateAlbumKey=${localBest?.first?.album?.let { cleanString(context, it) }.orEmpty()}, " +
                         "titleMatched=${localBest?.second?.titleMatched}, " +
                         "artistMatched=${localBest?.second?.artistMatched}, " +
                         "albumMatched=${localBest?.second?.albumMatched}, " +
@@ -189,16 +198,28 @@ object OnlineLyricTargeter {
                     .take(MAX_LYRIC_CANDIDATES_PER_QUERY)
                     .toList()
                 for ((candidate, candidateMatch) in eligibleCandidates) {
+                    val resolvedCandidate = resolveCandidateArtistAlias(
+                        context = context,
+                        source = source,
+                        candidate = candidate,
+                        candidateMatch = candidateMatch,
+                        cleanLocalTitle = cleanLocalTitle,
+                        cleanLocalAlbum = cleanLocalAlbum,
+                        localFeatures = localFeatures,
+                        durationMs = durationMs,
+                        metadataLabel = metadataLabel,
+                        diagnostic = diagnostic,
+                    ) ?: candidate
                     val lyricsResult = withTimeoutOrNull(TIMEOUT_MS) {
                         try {
-                            source.getLyrics(candidate)
+                            source.getLyrics(resolvedCandidate)
                         } catch (e: CancellationException) {
                             throw e
                         } catch (e: Exception) {
                             LogManager.w(
                                 "OnlineTargeter",
                                 "获取歌词异常: 源=${source.javaClass.simpleName}, " +
-                                    "id=${candidate.id}, ${e.message}"
+                                    "id=${resolvedCandidate.id}, ${e.message}"
                             )
                             null
                         }
@@ -210,7 +231,7 @@ object OnlineLyricTargeter {
                         LogManager.d(
                             "OnlineTargeter",
                             "候选无可用歌词，尝试下一条: 源=${source.javaClass.simpleName}, " +
-                                "id=${candidate.id}, score=${candidateMatch.total}"
+                                "id=${resolvedCandidate.id}, score=${candidateMatch.total}"
                         )
                         continue
                     }
@@ -253,6 +274,57 @@ object OnlineLyricTargeter {
                 "album=$album, bestScore=$bestScore, requirement=title+(artist|album)"
         )
         return null
+    }
+
+    /**
+     * A catalog may expose a creator under a different public name (for example KZ/livetune).
+     * Once title+album identifies a candidate, use that candidate's artist as the next query
+     * identity instead of maintaining provider-specific alias tables.
+     */
+    private suspend fun resolveCandidateArtistAlias(
+        context: Context,
+        source: SearchSource,
+        candidate: SongSearchResult,
+        candidateMatch: CandidateMatch,
+        cleanLocalTitle: String,
+        cleanLocalAlbum: String,
+        localFeatures: List<String>,
+        durationMs: Long,
+        metadataLabel: String,
+        diagnostic: ((String) -> Unit)?,
+    ): SongSearchResult? {
+        if (candidateMatch.artistMatched || !candidateMatch.albumMatched) return null
+        val aliasQuery = listOf(candidate.title, candidate.artist, candidate.album)
+            .filter(String::isNotBlank)
+            .joinToString(" ")
+        val aliasResults = withTimeoutOrNull(TIMEOUT_MS) {
+            runCatching { source.search(aliasQuery, 1, "/", SEARCH_PAGE_SIZE) }.getOrNull()
+        }.orEmpty()
+        val canonicalArtists = splitArtists(candidate.artist)
+            .map { cleanString(context, it) }
+        val canonical = aliasResults
+            .map { song ->
+                song to calculateScore(
+                    context,
+                    song,
+                    cleanLocalTitle,
+                    canonicalArtists,
+                    cleanLocalAlbum,
+                    localFeatures,
+                    durationMs,
+                )
+            }
+            .filter { (_, score) -> score.isEligible }
+            .maxByOrNull { (_, score) -> score.total }
+            ?.first
+        diagnostic?.invoke(
+            "在线候选歌手回填: metadata=$metadataLabel, " +
+                "source=${source.javaClass.simpleName}, " +
+                "fromArtist=${candidate.artist}, query=\"$aliasQuery\", " +
+                "resolvedArtist=${canonical?.artist ?: candidate.artist}, " +
+                "resolved=${canonical != null}"
+        )
+        return canonical
     }
 
     internal fun shouldRetryWithOriginalMetadata(
@@ -346,7 +418,7 @@ object OnlineLyricTargeter {
 
         val titleMatched = stringsMatch(cleanLocalTitle, cleanSongTitle)
         if (titleMatched) {
-            score += 50
+            score += TITLE_SCORE
         }
 
         val songArtists = splitArtists(song.artist).map { cleanString(context, it) }
@@ -354,21 +426,19 @@ object OnlineLyricTargeter {
         val artistMatched = localArtists.any { localArtist ->
             songArtists.any { songArtist -> stringsMatch(localArtist, songArtist) }
         }
-        if (artistMatched) {
-            score += 30
-        }
+        if (artistMatched) score += ARTIST_SCORE
 
         val cleanSongAlbum = cleanString(context, song.album)
         val albumMatched = cleanLocalAlbum.isNotEmpty() && cleanSongAlbum.isNotEmpty() &&
             stringsMatch(cleanLocalAlbum, cleanSongAlbum)
-        if (albumMatched) score += 30
+        if (albumMatched) score += ALBUM_SCORE
 
         val songFeatures = listOf("live", "remastered", "翻唱", "cover").filter { song.title.lowercase().contains(it) }
         
         if (localFeatures.isNotEmpty() && songFeatures.isNotEmpty()) {
             val commonFeatures = localFeatures.intersect(songFeatures.toSet())
             if (commonFeatures.isNotEmpty()) {
-                score += 20
+                score += FEATURE_SCORE
             }
         }
 
@@ -385,8 +455,17 @@ object OnlineLyricTargeter {
             .replace(BRACKETED_SEGMENT_REGEX, "")
             .trim()
             .lowercase()
-        return compactWhitespace(ChineseUtils.toSimplified(context, cleaned))
+        return compactWhitespace(
+            normalizeMatchText(ChineseUtils.toSimplified(context, cleaned))
+        )
     }
+
+    /** Build the same identity key for catalog punctuation, spacing, and invisible format chars. */
+    internal fun normalizeMatchText(value: String): String =
+        Normalizer.normalize(value, Normalizer.Form.NFKC)
+            .lowercase()
+            .replace(BRACKETED_SEGMENT_REGEX, "")
+            .replace(MATCH_IGNORED_REGEX, "")
 
     internal fun normalizeWidth(value: String): String =
         Normalizer.normalize(value, Normalizer.Form.NFKC)
@@ -394,9 +473,9 @@ object OnlineLyricTargeter {
     internal fun durationScore(localDurationMs: Long, remoteDurationMs: Long): Int {
         val diffMs = abs(localDurationMs - remoteDurationMs)
         return when {
-            diffMs > 5_000L -> -30
-            diffMs < 1_500L -> 15
-            else -> 10
+            diffMs > 5_000L -> DURATION_MISMATCH_SCORE
+            diffMs < 1_500L -> DURATION_CLOSE_SCORE
+            else -> DURATION_DRIFT_SCORE
         }
     }
 
@@ -455,6 +534,7 @@ object OnlineLyricTargeter {
     private val BRACKETED_SEGMENT_REGEX = Regex(
         "\\([^)]*\\)|\\[[^\\]]*\\]|\\{[^}]*\\}",
     )
+    private val MATCH_IGNORED_REGEX = Regex("[\\p{P}\\p{S}\\p{Cf}\\s]")
 
     internal data class CandidateMatch(
         val total: Int,

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/root/island/renderer/BaseIslandRenderer.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/root/island/renderer/BaseIslandRenderer.kt
@@ -97,6 +97,19 @@ object BaseIslandRenderer : IslandRenderer {
         val config = IslandSlotRuntimeConfig.from(prefs)
         activeViews.forEach { (cv, _) ->
             cv.post {
+                if (LyriconDataBridge.currentLyricPackageName != lyricPkg ||
+                    !cv.isAttachedToWindow
+                ) {
+                    DisplayDiagnosticLogger.log(
+                        channel = "ISLAND",
+                        result = "skipped",
+                        reason = "stale_refresh_task",
+                        extra = "scheduledPackage=$lyricPkg, " +
+                            "currentPackage=${LyriconDataBridge.currentLyricPackageName}",
+                        dedupeKey = "ISLAND/refresh",
+                    )
+                    return@post
+                }
                 val injectionChanged = IslandLyricTextInjector.injectSlots(cv)
                 if (injectionChanged) {
                     IslandHostFacade.triggerSystemRelayout(cv)
@@ -154,15 +167,44 @@ object BaseIslandRenderer : IslandRenderer {
         }
         activeViews.forEach { (cv, _) ->
                 cv.post {
-                    if (!IslandLyricTextInjector.hasInjectedLyricText(cv)) {
+                    if (LyriconDataBridge.currentLyricPackageName != lyricPkg ||
+                        !cv.isAttachedToWindow
+                    ) {
                         DisplayDiagnosticLogger.log(
                             channel = "ISLAND",
                             result = "skipped",
-                            reason = "injected_view_missing",
-                            extra = "targetViews=${activeViews.size}",
+                            reason = "stale_line_task",
+                            extra = "scheduledPackage=$lyricPkg, " +
+                                "currentPackage=${LyriconDataBridge.currentLyricPackageName}",
                             dedupeKey = "ISLAND/line",
                         )
                         return@post
+                    }
+                    if (!IslandLyricTextInjector.hasInjectedLyricText(cv)) {
+                        val injectionChanged = IslandLyricTextInjector.injectSlots(
+                            rootView = cv,
+                            reconfigureExisting = false,
+                        )
+                        if (injectionChanged) {
+                            IslandHostFacade.triggerSystemRelayout(cv)
+                        }
+                        if (!IslandLyricTextInjector.hasInjectedLyricText(cv)) {
+                            DisplayDiagnosticLogger.log(
+                                channel = "ISLAND",
+                                result = "skipped",
+                                reason = "injected_view_recovery_failed",
+                                extra = "targetViews=${activeViews.size}",
+                                dedupeKey = "ISLAND/line",
+                            )
+                            return@post
+                        }
+                        DisplayDiagnosticLogger.log(
+                            channel = "ISLAND",
+                            result = "recovered",
+                            reason = "injected_view_recreated",
+                            extra = "targetViews=${activeViews.size}",
+                            dedupeKey = "ISLAND/line",
+                        )
                     }
                     updateLyricContentForView(cv, prefs, config)
                     DisplayDiagnosticLogger.log(

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/root/source/AppleOnlineTranslationRequestPolicy.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/root/source/AppleOnlineTranslationRequestPolicy.kt
@@ -40,19 +40,36 @@ internal object AppleOnlineTranslationRequestPolicy {
         song.metadata?.getString(LyricMetadataKeys.APPLE_ALBUM),
     ).mapNotNull { it?.trim()?.takeIf(String::isNotEmpty) }.firstOrNull().orEmpty()
 
+    /** Do not spend a lookup on Apple's transient payload before album replacement arrives. */
+    fun shouldWaitForMatchingAlbum(song: Song?, preferOriginalMetadata: Boolean): Boolean =
+        preferOriginalMetadata && song != null && effectiveAlbum(song).isEmpty() &&
+            !song.metadata
+                ?.getString(LyricMetadataKeys.APPLE_ORIGINAL_METADATA_RESOLVED)
+                .toBoolean()
+
     fun originalMetadataChanged(previous: Song?, current: Song?): Boolean =
         previous != null && current != null && originalMetadataKey(previous) != originalMetadataKey(current)
+
+    /** Metadata that is actually sent to the Q/NetEase matcher changed. */
+    fun matchingMetadataChanged(previous: Song?, current: Song?): Boolean =
+        previous != null && current != null && matchingMetadataKey(previous) != matchingMetadataKey(current)
 
     fun attemptKey(song: Song): String {
         val trackKey = song.id?.trim()?.takeIf(String::isNotEmpty)?.let { "id:$it" }
             ?: "${normalize(song.name)}|${normalize(song.artist)}"
-        return "$trackKey|${originalMetadataKey(song)}"
+        return "$trackKey|${originalMetadataKey(song)}|${matchingMetadataKey(song)}"
     }
 
     private fun originalMetadataKey(song: Song): String = listOf(
         song.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_TITLE),
         song.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ARTIST),
         song.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ALBUM),
+    ).joinToString("|") { normalize(it) }
+
+    private fun matchingMetadataKey(song: Song): String = listOf(
+        song.name,
+        song.artist,
+        effectiveAlbum(song),
     ).joinToString("|") { normalize(it) }
 
     private fun isOriginalMetadataResolved(song: Song): Boolean = song.metadata

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/root/source/AppleOnlineTranslationRequestPolicy.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/root/source/AppleOnlineTranslationRequestPolicy.kt
@@ -9,16 +9,36 @@ internal object AppleOnlineTranslationRequestPolicy {
         val waitForResult: Boolean,
     )
 
-    /**
-     * Original metadata improves search precision, but its cross-process request has no
-     * acknowledgement. Start with current metadata and rematch when a resolved alias arrives.
-     */
+    /** When replacement is requested, do not race an online lookup against localized metadata. */
     fun originalMetadataLookupPlan(
         shouldRequestOriginalMetadata: Boolean,
     ): OriginalMetadataLookupPlan = OriginalMetadataLookupPlan(
         requestOriginalMetadata = shouldRequestOriginalMetadata,
-        waitForResult = false,
+        waitForResult = shouldRequestOriginalMetadata,
     )
+
+    fun applyResolvedReplacement(song: Song?, enabled: Boolean): Song? {
+        song ?: return null
+        if (!enabled || !isOriginalMetadataResolved(song)) return song
+        val title = song.metadata
+            ?.getString(LyricMetadataKeys.APPLE_ORIGINAL_TITLE)
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+        val artist = song.metadata
+            ?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ARTIST)
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+        if (title == null && artist == null) return song
+        return song.copy(
+            name = title ?: song.name,
+            artist = artist ?: song.artist,
+        )
+    }
+
+    fun effectiveAlbum(song: Song): String = sequenceOf(
+        song.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ALBUM),
+        song.metadata?.getString(LyricMetadataKeys.APPLE_ALBUM),
+    ).mapNotNull { it?.trim()?.takeIf(String::isNotEmpty) }.firstOrNull().orEmpty()
 
     fun originalMetadataChanged(previous: Song?, current: Song?): Boolean =
         previous != null && current != null && originalMetadataKey(previous) != originalMetadataKey(current)
@@ -31,8 +51,13 @@ internal object AppleOnlineTranslationRequestPolicy {
 
     private fun originalMetadataKey(song: Song): String = listOf(
         song.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_TITLE),
-        song.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ARTIST)
+        song.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ARTIST),
+        song.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ALBUM),
     ).joinToString("|") { normalize(it) }
+
+    private fun isOriginalMetadataResolved(song: Song): Boolean = song.metadata
+        ?.getString(LyricMetadataKeys.APPLE_ORIGINAL_METADATA_RESOLVED)
+        .toBoolean()
 
     private fun normalize(value: String?): String = value.orEmpty().trim().lowercase()
 }

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/root/source/LyriconSource.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/root/source/LyriconSource.kt
@@ -41,14 +41,13 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlin.math.abs
 
 class LyriconSource : LyricSource {
 
     companion object {
         private const val TAG = "LyriconSource"
+        private const val MATCH_TAG = "LyriconMatch"
         private const val APPLE_MUSIC_PACKAGE = "com.apple.android.music"
         private const val BUILT_IN_PROVIDER_PACKAGE = "com.juren233.hyperlyricsenhanced"
         private const val APPLE_LYRICS_GRACE_MS = 5_000L
@@ -83,7 +82,6 @@ class LyriconSource : LyricSource {
     private var directBridge: AppleMusicDirectBridge? = null
     private val mainHandler = Handler(Looper.getMainLooper())
     private val fallbackScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private val fallbackRequestMutex = Mutex()
     private val mediaPositionScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
     private var fallbackJob: Job? = null
     private var onlineTranslationJob: Job? = null
@@ -359,7 +357,27 @@ class LyriconSource : LyricSource {
         ) ?: RootConstants.DEFAULT_HOOK_LYRICON_PROVIDER_DELAY
     }
 
-    private fun handleAppleSong(song: LocalSong?) {
+    private fun handleAppleSong(incomingSong: LocalSong?) {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            mainHandler.post { handleAppleSong(incomingSong) }
+            return
+        }
+        if (sink == null) return
+        val song = AppleOnlineTranslationRequestPolicy.applyResolvedReplacement(
+            song = incomingSong,
+            enabled = shouldPreferAppleOriginalMetadata(),
+        )
+        if (
+            incomingSong != null && song != null &&
+            (incomingSong.name != song.name || incomingSong.artist != song.artist)
+        ) {
+            diagnostic(
+                "Apple Music 歌曲载荷已按专辑替换表改写: id=${song.id}, " +
+                    "before=${incomingSong.name}/${incomingSong.artist}, " +
+                    "after=${song.name}/${song.artist}, " +
+                    "album=${AppleOnlineTranslationRequestPolicy.effectiveAlbum(song)}"
+            )
+        }
         diagnostic(
             "Apple Music 歌曲入口: id=${song?.id}, title=${song?.name}, " +
                 "artist=${song?.artist}, duration=${song?.duration}, " +
@@ -565,12 +583,15 @@ class LyriconSource : LyricSource {
             }
             fallbackJob = fallbackScope.launch {
                 try {
-                    fallbackRequestMutex.withLock {
-                        if (generation != fallbackGeneration) return@withLock
+                    run request@ {
+                        if (generation != fallbackGeneration) return@request
                         val preferredSource = if (isQqFirst()) Source.QM else Source.NE
+                        val replacedAlbum =
+                            AppleOnlineTranslationRequestPolicy.effectiveAlbum(baseSong)
                         diagnostic(
                             "Apple Music 在线兜底开始: title=${baseSong.name}, " +
-                                "artist=${baseSong.artist}, source=$preferredSource"
+                                "artist=${baseSong.artist}, album=$replacedAlbum, " +
+                                "source=$preferredSource"
                         )
                         val lines = OnlineLyricTargeter.fetchBestLyric(
                             context = application,
@@ -578,12 +599,9 @@ class LyriconSource : LyricSource {
                             title = baseSong.name.orEmpty(),
                             artist = baseSong.artist.orEmpty(),
                             durationMs = baseSong.duration,
-                            originalTitle = baseSong.metadata
-                                ?.getString(LyricMetadataKeys.APPLE_ORIGINAL_TITLE),
-                            originalArtist = baseSong.metadata
-                                ?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ARTIST),
-                            preferOriginalMetadata = shouldPreferAppleOriginalMetadata(),
-                            preferredSource = preferredSource
+                            album = replacedAlbum,
+                            preferredSource = preferredSource,
+                            diagnostic = { message -> diagnostic(message) },
                         )
                         val fallbackSong = lines?.let {
                             OnlineFallbackSongMapper.map(baseSong, it)
@@ -709,21 +727,21 @@ class LyriconSource : LyricSource {
         onlineTranslationJob?.cancel()
         onlineTranslationJob = fallbackScope.launch {
             try {
-                fallbackRequestMutex.withLock {
-                    if (generation != onlineTranslationGeneration) {
+                    run request@ {
+                        if (generation != onlineTranslationGeneration) {
                         pronunciationDiagnostic(
                             "stage=request_abandoned, generation=$generation, id=${baseSong.id}, " +
                                 "reason=generation_changed_before_start, " +
                                 "currentGeneration=$onlineTranslationGeneration"
                         )
-                        return@withLock
+                            return@request
                     }
                     val application = app ?: run {
                         pronunciationDiagnostic(
                             "stage=request_abandoned, generation=$generation, id=${baseSong.id}, " +
                                 "reason=application_unavailable"
                         )
-                        return@withLock
+                            return@request
                     }
                     val preferredSource = if (isTranslationQqFirst()) Source.QM else Source.NE
                     val alternativeSource = if (preferredSource == Source.QM) Source.NE else Source.QM
@@ -747,29 +765,20 @@ class LyriconSource : LyricSource {
                             ) 1 else 0)
                         }
                     }
-                    val mediaInfo = MediaMetadataHelper.getMediaInfo(
-                        application,
-                        APPLE_MUSIC_PACKAGE,
-                    )
-                    val searchDuration = AppleOnlineTranslationSearchDurationPolicy.resolve(
-                        song = baseSong,
-                        media = AppleOnlineTranslationSearchDurationPolicy.MediaSnapshot(
-                            title = mediaInfo.title,
-                            artist = mediaInfo.artist,
-                            durationMs = mediaInfo.duration,
-                        ),
-                    )
+                    val replacedAlbum =
+                        AppleOnlineTranslationRequestPolicy.effectiveAlbum(baseSong)
+                    val searchDurationMs = baseSong.duration
                     diagnostic(
                         "Apple Music 在线歌词补全开始: title=${baseSong.name}, " +
-                            "artist=${baseSong.artist}, preferred=$preferredSource, " +
+                            "artist=${baseSong.artist}, album=$replacedAlbum, " +
+                            "metadataSource=apple_replaced_payload, " +
+                            "preferred=$preferredSource, " +
                             "first=$firstSource, requested=${requestedFirstSource ?: "none"}"
                     )
                     pronunciationDiagnostic(
                         "stage=search_duration_resolved, generation=$generation, id=${baseSong.id}, " +
-                            "lyricDuration=${baseSong.duration}, mediaDuration=${mediaInfo.duration}, " +
-                            "mediaTitle=${mediaInfo.title}, mediaArtist=${mediaInfo.artist}, " +
-                            "identityMatched=${searchDuration.mediaIdentityMatched}, " +
-                            "selectedDuration=${searchDuration.durationMs}"
+                            "lyricDuration=${baseSong.duration}, metadataSource=apple_replaced_payload, " +
+                            "selectedDuration=$searchDurationMs"
                     )
                     pronunciationDiagnostic(
                         "stage=request_started, generation=$generation, id=${baseSong.id}, " +
@@ -783,7 +792,8 @@ class LyriconSource : LyricSource {
                         source = firstSource,
                         totalLineCount = totalLineCount,
                         generation = generation,
-                        searchDurationMs = searchDuration.durationMs,
+                        searchDurationMs = searchDurationMs,
+                        album = replacedAlbum,
                     )
                     val secondCandidate = if (
                         temporaryTranslationSource == secondSource ||
@@ -803,7 +813,8 @@ class LyriconSource : LyricSource {
                             source = secondSource,
                             totalLineCount = totalLineCount,
                             generation = generation,
-                            searchDurationMs = searchDuration.durationMs,
+                            searchDurationMs = searchDurationMs,
+                            album = replacedAlbum,
                         )
                     } else {
                         null
@@ -898,12 +909,20 @@ class LyriconSource : LyricSource {
                     }
                 }
             } catch (e: CancellationException) {
+                matchDiagnostic(
+                    "Apple Music 在线翻译最终状态: title=${baseSong.name}, matched=false, " +
+                        "reason=cancelled, generation=$generation"
+                )
                 pronunciationDiagnostic(
                     "stage=request_cancelled, generation=$generation, id=${baseSong.id}, " +
                         "currentGeneration=$onlineTranslationGeneration"
                 )
                 throw e
             } catch (e: Exception) {
+                matchDiagnostic(
+                    "Apple Music 在线翻译最终状态: title=${baseSong.name}, matched=false, " +
+                        "reason=exception:${e.javaClass.simpleName}, generation=$generation"
+                )
                 pronunciationDiagnostic(
                     "stage=request_failed, generation=$generation, id=${baseSong.id}, " +
                         "error=${e.javaClass.name}, message=${e.message}"
@@ -924,6 +943,7 @@ class LyriconSource : LyricSource {
         totalLineCount: Int,
         generation: Int,
         searchDurationMs: Long,
+        album: String,
     ): OnlineTranslationSelector.Candidate? {
         pronunciationDiagnostic(
             "stage=candidate_fetch_started, generation=$generation, id=${baseSong.id}, source=$source"
@@ -934,20 +954,17 @@ class LyriconSource : LyricSource {
             title = baseSong.name.orEmpty(),
             artist = baseSong.artist.orEmpty(),
             durationMs = searchDurationMs,
-            originalTitle = baseSong.metadata
-                ?.getString(LyricMetadataKeys.APPLE_ORIGINAL_TITLE),
-            originalArtist = baseSong.metadata
-                ?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ARTIST),
-            preferOriginalMetadata = shouldPreferAppleOriginalMetadata(),
+            album = album,
             preferredSource = source,
             requireTranslation = false,
-            fallbackToOtherSources = false
+            fallbackToOtherSources = false,
+            diagnostic = { message -> matchDiagnostic(message) },
         ) ?: run {
             pronunciationDiagnostic(
                 "stage=candidate_fetch_finished, generation=$generation, id=${baseSong.id}, " +
                     "source=$source, found=false"
             )
-            diagnostic(
+            matchDiagnostic(
                 "Apple Music 在线翻译候选未命中: title=${baseSong.name}, source=$source"
             )
             return null
@@ -996,7 +1013,7 @@ class LyriconSource : LyricSource {
                 "matchedPronunciation=$matchedPronunciationCount, " +
                 "resultRomanized=${enrichedLines.count { !it.roma.isNullOrBlank() }}"
         )
-        diagnostic(
+        matchDiagnostic(
             "Apple Music 在线翻译候选: title=${baseSong.name}, source=$source, " +
                 "lines=${candidate.onlineLineCount}, " +
                 "translated=${candidate.translatedLineCount}, " +
@@ -1034,6 +1051,11 @@ class LyriconSource : LyricSource {
                 "candidateSources=${selection?.onlineLinesBySource?.keys?.joinToString("+").orEmpty()}"
         )
         if (!requestStillCurrent) {
+            matchDiagnostic(
+                "Apple Music 在线翻译最终状态: title=${baseSong.name}, matched=false, " +
+                    "reason=stale_result, generation=$generation, " +
+                    "currentGeneration=$onlineTranslationGeneration"
+            )
             diagnostic(
                 "Apple Music 在线翻译匹配结果已过期: title=${baseSong.name}, " +
                     "generation=$generation, currentGeneration=$onlineTranslationGeneration"
@@ -1084,7 +1106,10 @@ class LyriconSource : LyricSource {
                 "hasOnlineEnrichment=$hasOnlineEnrichment, sourceSwitch=$hasPendingSourceSwitch"
         )
         if (mergedResult == null || (!hasOnlineEnrichment && !hasPendingSourceSwitch)) {
-            diagnostic("Apple Music 在线翻译匹配未命中: title=${baseSong.name}")
+            matchDiagnostic(
+                "Apple Music 在线翻译最终状态: title=${baseSong.name}, matched=false, " +
+                    "reason=no_usable_enrichment, generation=$generation"
+            )
             HookLogger.i(TAG, "Apple Music 在线翻译匹配未命中: title=${baseSong.name}")
             if (requestOriginalMetadata(baseSong, "translation_match_miss")) return
             completePendingOnlineSourceSwitchRequests(null)
@@ -1101,8 +1126,8 @@ class LyriconSource : LyricSource {
         }
 
         onlineMatchedTranslationActive = hasOnlineEnrichment
-        diagnostic(
-            "Apple Music 在线翻译结果接受: title=${baseSong.name}, " +
+        matchDiagnostic(
+            "Apple Music 在线翻译最终状态: title=${baseSong.name}, matched=true, " +
                 "matched=${mergedResult.matchedCount}, enriched=$hasOnlineEnrichment, " +
                 "sourceSwitch=$hasPendingSourceSwitch, total=${baseSong.lyrics.orEmpty().size}"
         )
@@ -1462,6 +1487,10 @@ class LyriconSource : LyricSource {
         if (BuildConfig.DEBUG) HookLogger.w(TAG, "[debug] $message")
     }
 
+    private fun matchDiagnostic(message: String) {
+        if (BuildConfig.DEBUG) HookLogger.w(MATCH_TAG, message)
+    }
+
     private fun pronunciationDiagnostic(message: String) {
         if (BuildConfig.DEBUG) Log.i(PRONUNCIATION_DIAGNOSTIC_TAG, message)
     }
@@ -1480,6 +1509,60 @@ class LyriconSource : LyricSource {
         sub.register()
     }
 
+    private fun handleActiveProviderChanged(providerInfo: ProviderInfo?) {
+        if (sink == null) return
+        val playerPackageName = providerInfo?.playerPackageName
+        activeCentralPlayerPackageName = playerPackageName
+        if (playerPackageName == null && currentAppleSong != null) {
+            centralAppleProviderActive = false
+            diagnostic(
+                "忽略 Central 空提供者状态: directTitle=${currentAppleSong?.name}"
+            )
+            return
+        }
+
+        cancelFallback(clearAppleSong = true, reason = "central_provider_changed")
+        cancelOnlineTranslation(
+            clearAttempt = true,
+            clearMatched = true,
+            reason = "central_provider_changed"
+        )
+        lastAdjustedPosition = 0L
+        sink?.onStop()
+        centralAppleProviderActive = playerPackageName == APPLE_MUSIC_PACKAGE
+        if (!centralAppleProviderActive) {
+            currentPublishedAppleSong = null
+            currentPublishedAppleOnlineTranslationMatched = false
+        }
+        activeProviderPackageName = providerInfo?.providerPackageName
+        activeProviderDelayMs = providerInfo?.providerPackageName
+            ?.let(::readProviderDelay)
+            ?: RootConstants.DEFAULT_HOOK_LYRICON_PROVIDER_DELAY
+        LyriconDataBridge.updateLyricPackage(playerPackageName)
+    }
+
+    private fun handleCentralSongChanged(localSong: LocalSong?) {
+        if (sink == null) return
+        if (centralAppleProviderActive) {
+            handleAppleSong(localSong)
+        } else {
+            if (activeCentralPlayerPackageName == null) {
+                diagnostic(
+                    "忽略无活动提供者的 Central 歌曲回调: " +
+                        "title=${localSong?.name}, directTitle=${currentAppleSong?.name}"
+                )
+                return
+            }
+            cancelFallback(clearAppleSong = true, reason = "central_non_apple_song")
+            cancelOnlineTranslation(
+                clearAttempt = true,
+                clearMatched = true,
+                reason = "central_non_apple_song"
+            )
+            publishSong(localSong, restorePosition = false)
+        }
+    }
+
     private val connectionListener = object : ConnectionListener {
         override fun onConnected(subscriber: LyriconSubscriber) {
                 HookLogger.i(TAG, "订阅连接已建立")
@@ -1492,78 +1575,35 @@ class LyriconSource : LyricSource {
         }
 
         override fun onDisconnected(subscriber: LyriconSubscriber) {
+            mainHandler.post {
                 centralAppleProviderActive = false
                 activeCentralPlayerPackageName = null
                 activeProviderPackageName = null
                 HookLogger.w(TAG, "订阅连接已断开")
+            }
         }
 
         override fun onConnectTimeout(subscriber: LyriconSubscriber) {
+            mainHandler.post {
                 centralAppleProviderActive = false
                 activeCentralPlayerPackageName = null
                 activeProviderPackageName = null
                 HookLogger.w(TAG, "订阅连接超时")
-                mainHandler.post {
-                    onCentralConnectTimeout?.invoke()
-                    subscriber.register()
-                }
+                onCentralConnectTimeout?.invoke()
+                subscriber.register()
+            }
         }
     }
 
     private val activePlayerListener = object : ActivePlayerListener {
         override fun onActiveProviderChanged(providerInfo: ProviderInfo?) {
-            val playerPackageName = providerInfo?.playerPackageName
-            activeCentralPlayerPackageName = playerPackageName
-            if (playerPackageName == null && currentAppleSong != null) {
-                centralAppleProviderActive = false
-                diagnostic(
-                    "忽略 Central 空提供者状态: directTitle=${currentAppleSong?.name}"
-                )
-                return
-            }
-
-            cancelFallback(clearAppleSong = true, reason = "central_provider_changed")
-            cancelOnlineTranslation(
-                clearAttempt = true,
-                clearMatched = true,
-                reason = "central_provider_changed"
-            )
-            lastAdjustedPosition = 0L
-            sink?.onStop()
-            centralAppleProviderActive =
-                playerPackageName == APPLE_MUSIC_PACKAGE
-            if (!centralAppleProviderActive) {
-                currentPublishedAppleSong = null
-                currentPublishedAppleOnlineTranslationMatched = false
-            }
-            activeProviderPackageName = providerInfo?.providerPackageName
-            activeProviderDelayMs = providerInfo?.providerPackageName
-                ?.let(::readProviderDelay)
-                ?: RootConstants.DEFAULT_HOOK_LYRICON_PROVIDER_DELAY
-            LyriconDataBridge.updateLyricPackage(playerPackageName)
+            mainHandler.post { handleActiveProviderChanged(providerInfo) }
         }
 
 
         override fun onSongChanged(song: LyriconSong?) {
             val localSong = song?.toLocalSong()
-            if (centralAppleProviderActive) {
-                handleAppleSong(localSong)
-            } else {
-                if (activeCentralPlayerPackageName == null) {
-                    diagnostic(
-                        "忽略无活动提供者的 Central 歌曲回调: " +
-                            "title=${localSong?.name}, directTitle=${currentAppleSong?.name}"
-                    )
-                    return
-                }
-                cancelFallback(clearAppleSong = true, reason = "central_non_apple_song")
-                cancelOnlineTranslation(
-                    clearAttempt = true,
-                    clearMatched = true,
-                    reason = "central_non_apple_song"
-                )
-                publishSong(localSong, restorePosition = false)
-            }
+            mainHandler.post { handleCentralSongChanged(localSong) }
         }
 
         override fun onPlaybackStateChanged(isPlaying: Boolean) {
@@ -1648,6 +1688,11 @@ class LyriconSource : LyricSource {
 
     internal fun onDirectSongChanged(song: LyriconSong?) {
         val localSong = song?.toLocalSong()
+        mainHandler.post { handleDirectSongChanged(localSong) }
+    }
+
+    private fun handleDirectSongChanged(localSong: LocalSong?) {
+        if (sink == null) return
         currentDirectAppleSongId = localSong?.id
         appleDirectPositionReference = null
         if (hasActiveCentralPlayer()) return
@@ -1799,6 +1844,18 @@ class LyriconSource : LyricSource {
         contentType: String?,
         sourceName: String?,
     ) {
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            mainHandler.post {
+                onDirectOnlineLyricContentSourceRequested(
+                    requestId = requestId,
+                    songId = songId,
+                    contentType = contentType,
+                    sourceName = sourceName,
+                )
+            }
+            return
+        }
+        if (sink == null) return
         val nativeSong = currentAppleSong
         val requestedSource = runCatching { Source.valueOf(sourceName.orEmpty()) }
             .getOrNull()

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/root/source/LyriconSource.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/root/source/LyriconSource.kt
@@ -393,6 +393,8 @@ class LyriconSource : LyricSource {
         }
         val originalMetadataChanged = sameTrack &&
             AppleOnlineTranslationRequestPolicy.originalMetadataChanged(previousSong, song)
+        val matchingMetadataChanged = sameTrack &&
+            AppleOnlineTranslationRequestPolicy.matchingMetadataChanged(previousSong, song)
         val repeatedEmptySong = sameTrack && !originalMetadataChanged && song.lyrics.isNullOrEmpty() &&
             (fallbackSongActive || fallbackDelayRunnable != null || fallbackJob?.isActive == true)
         if (repeatedEmptySong) {
@@ -404,7 +406,7 @@ class LyriconSource : LyricSource {
         val repeatedNativeNeedingEnrichment = sameTrack &&
             !song.lyrics.isNullOrEmpty() &&
             needsOnlineEnrichment(song) &&
-            !originalMetadataChanged &&
+            !matchingMetadataChanged &&
             (onlineTranslationJob?.isActive == true || onlineMatchedTranslationActive)
         if (repeatedNativeNeedingEnrichment) {
             currentAppleSong = song
@@ -416,7 +418,7 @@ class LyriconSource : LyricSource {
         val incomingHasTranslation = hasTranslation(song)
         val incomingNeedsEnrichment = needsOnlineEnrichment(song)
         cancelOnlineTranslation(
-            clearAttempt = !sameTrack || !incomingNeedsEnrichment || originalMetadataChanged,
+            clearAttempt = !sameTrack || !incomingNeedsEnrichment || matchingMetadataChanged,
             clearMatched = true,
             reason = "apple_song_updated"
         )
@@ -444,7 +446,8 @@ class LyriconSource : LyricSource {
                 "titlePresent=${!song?.name.isNullOrBlank()}, " +
                 "requestOriginal=${originalMetadataPlan.requestOriginalMetadata}, " +
                 "waitOriginal=${originalMetadataPlan.waitForResult}, sameTrack=$sameTrack, " +
-                "originalMetadataChanged=$originalMetadataChanged"
+                "originalMetadataChanged=$originalMetadataChanged, " +
+                "matchingMetadataChanged=$matchingMetadataChanged"
         )
         if (song != null && originalMetadataPlan.requestOriginalMetadata) {
             requestOriginalMetadata(song, "setting_enabled")
@@ -699,6 +702,18 @@ class LyriconSource : LyricSource {
         val nativeLineCount = baseSong.lyrics.orEmpty().size
         val enrichmentNeeded = needsOnlineEnrichment(baseSong)
         val titlePresent = !baseSong.name.isNullOrBlank()
+        if (AppleOnlineTranslationRequestPolicy.shouldWaitForMatchingAlbum(
+                baseSong,
+                shouldPreferAppleOriginalMetadata(),
+            )
+        ) {
+            pronunciationDiagnostic(
+                "stage=request_deferred, reason=matching_album_pending, " +
+                    "id=${baseSong.id}, title=${baseSong.name}, album=" +
+                    AppleOnlineTranslationRequestPolicy.effectiveAlbum(baseSong)
+            )
+            return false
+        }
         if (!matchingEnabled || nativeLineCount == 0 || !enrichmentNeeded || !titlePresent) {
             pronunciationDiagnostic(
                 "stage=request_schedule_skipped, reason=precondition_failed, " +

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/root/source/OnlineTranslationMatcher.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/root/source/OnlineTranslationMatcher.kt
@@ -14,7 +14,7 @@ internal object OnlineTranslationMatcher {
     private const val MIN_TEXT_SIMILARITY = 0.65
     private const val MATCH_TIME_WINDOW_MS = 15_000L
     private const val MAX_TIME_PENALTY = 0.20
-    private const val MAX_GROUP_SPAN = 3
+    private const val MAX_GROUP_SPAN = 6
     private const val GROUP_SPAN_PENALTY = 0.015
 
     data class Result(
@@ -727,8 +727,15 @@ internal object OnlineTranslationMatcher {
         ) {
             return translatedComponents.map { TranslationParts(it.trim(), null) }
         }
-        return splitTextByNativeWeights(translation, nativeGroup)
-            .map { it?.let { text -> TranslationParts(text, null) } }
+        val split = splitTextByNativeWeights(translation, nativeGroup)
+        if (split.any { it != null }) {
+            return split.map { it?.let { text -> TranslationParts(text, null) } }
+        }
+
+        // Apple can split one provider line into several display lines. When the translated
+        // sentence has no trustworthy delimiter, repeating it is safer than either cutting at
+        // arbitrary characters or leaving most of the Apple group untranslated.
+        return List(nativeGroup.size) { TranslationParts(translation, null) }
     }
 
     private fun nativeComponentsMatch(
@@ -758,8 +765,7 @@ internal object OnlineTranslationMatcher {
             .filter(String::isNotBlank)
         if (punctuationParts.size == count) return punctuationParts
 
-        // A translated sentence cannot be divided safely from source-language
-        // character ratios. Leave it unmatched so a later source or AI can fill it.
+        // Signal that there is no trustworthy split; the caller keeps the full sentence intact.
         return List(count) { null }
     }
 

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleDirectPlayer.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleDirectPlayer.kt
@@ -57,6 +57,10 @@ internal class AppleDirectPlayer(
     private var bridge: IAppleMusicLyricBridge? = null
     @Volatile
     private var latestSongPayload: ByteArray? = null
+    @Volatile
+    private var latestPlaybackState: Boolean? = null
+    @Volatile
+    private var latestPosition: Long? = null
     private var registered = false
 
     private val translationReceiver = object : IAppleMusicTranslationReceiver.Stub() {
@@ -167,6 +171,18 @@ internal class AppleDirectPlayer(
                 "直连重连后补发当前歌曲：bytes=${payload.size}, success=$replayed"
             )
         }
+        latestPlaybackState?.let { isPlaying ->
+            val replayed = send { target -> target.onPlaybackStateChanged(isPlaying) }
+            ProviderLogger.debug(
+                "直连重连后补发播放状态：playing=$isPlaying, success=$replayed"
+            )
+        }
+        latestPosition?.let { position ->
+            val replayed = send { target -> target.onPositionChanged(position) }
+            ProviderLogger.debug(
+                "直连重连后补发播放进度：position=$position, success=$replayed"
+            )
+        }
     }
 
     override val isActive: Boolean
@@ -181,15 +197,24 @@ internal class AppleDirectPlayer(
             return false
         }
         latestSongPayload = payload
+        latestPosition = null
         return send { target -> target.onSongChanged(payload) }
     }
 
-    override fun setPlaybackState(playing: Boolean): Boolean =
-        send { it.onPlaybackStateChanged(playing) }
+    override fun setPlaybackState(playing: Boolean): Boolean {
+        latestPlaybackState = playing
+        return send { it.onPlaybackStateChanged(playing) }
+    }
 
-    override fun seekTo(position: Long): Boolean = send { it.onSeekTo(position) }
+    override fun seekTo(position: Long): Boolean {
+        latestPosition = position.coerceAtLeast(0L)
+        return send { it.onSeekTo(position) }
+    }
 
-    override fun setPosition(position: Long): Boolean = send { it.onPositionChanged(position) }
+    override fun setPosition(position: Long): Boolean {
+        latestPosition = position.coerceAtLeast(0L)
+        return send { it.onPositionChanged(position) }
+    }
 
     override fun setPositionUpdateInterval(interval: Int): Boolean = true
 

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolver.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolver.kt
@@ -35,6 +35,8 @@ internal class AppleInternalCatalogResolver(
     private val catalogIdentityCache = ConcurrentHashMap<String, CatalogIdentity>()
     private val catalogIdentityInFlight =
         mutableMapOf<String, MutableList<(CatalogIdentity) -> Unit>>()
+    private val originalAlbumSequenceInFlight = mutableSetOf<String>()
+    private val originalAlbumSequenceCompleted = mutableSetOf<String>()
     private val originalEntityPending = LinkedHashMap<String, OriginalEntityRequest>()
     private var originalEntityBatchScheduled = false
     private var originalEntityBatchesRunning = 0
@@ -310,6 +312,7 @@ internal class AppleInternalCatalogResolver(
                     )
                 }?.let { cachedAlias ->
                     if (cachedAlias != alias) cache[metadata.id] = cachedAlias
+                    warmOriginalAlbumSequenceFromCachedSong(metadata.id, cachedAlias)
                     onResolved(
                         OriginalResolution(
                             alias = cachedAlias,
@@ -466,6 +469,7 @@ internal class AppleInternalCatalogResolver(
                             queryNext(index + 1)
                         } else {
                             queryByIsrc(isrc, language) { song ->
+                                song?.let { rememberCatalogIdentity(metadata.id, it) }
                                 song?.alias?.let(results::add)
                                 queryNext(index + 1)
                             }
@@ -1278,6 +1282,14 @@ internal class AppleInternalCatalogResolver(
         if (originalAlias != null) {
             synchronized(cache) { cache[metadata.id] = originalAlias }
             persistentOriginalCache.put(originalSongCacheKey(metadata.id), originalAlias)
+            catalogIdentityCache[metadata.id]?.albumIds?.let { albumIds ->
+                warmOriginalAlbumSequence(
+                    anchorMediaId = metadata.id,
+                    albumIds = albumIds,
+                    language = originalAlias.language,
+                    anchorAlias = originalAlias,
+                )
+            }
         }
         discardOriginalCandidates(metadata.id)
         val callbacks = synchronized(inFlight) { inFlight.remove(metadata.id).orEmpty() }
@@ -1296,6 +1308,7 @@ internal class AppleInternalCatalogResolver(
     }
 
     private fun finishCachedOriginalResolve(mediaId: String, alias: Alias) {
+        warmOriginalAlbumSequenceFromCachedSong(mediaId, alias)
         discardOriginalCandidates(mediaId)
         val callbacks = synchronized(inFlight) { inFlight.remove(mediaId).orEmpty() }
         ProviderLogger.info(
@@ -1308,6 +1321,33 @@ internal class AppleInternalCatalogResolver(
             artistIds = emptyList(),
         )
         callbacks.forEach { callback -> callback(resolution) }
+    }
+
+    private fun warmOriginalAlbumSequenceFromCachedSong(mediaId: String, alias: Alias) {
+        resolveCatalogIdentity(
+            mediaId = mediaId,
+            languages = listOf(alias.language),
+        ) { identity ->
+            val isrc = identity.isrc
+            if (isrc == null) {
+                warmOriginalAlbumSequence(
+                    anchorMediaId = mediaId,
+                    albumIds = identity.albumIds,
+                    language = alias.language,
+                    anchorAlias = alias,
+                )
+                return@resolveCatalogIdentity
+            }
+            queryByIsrc(isrc, alias.language) { regionalSong ->
+                regionalSong?.let { rememberCatalogIdentity(mediaId, it) }
+                warmOriginalAlbumSequence(
+                    anchorMediaId = mediaId,
+                    albumIds = (identity.albumIds + regionalSong?.albumIds.orEmpty()).distinct(),
+                    language = alias.language,
+                    anchorAlias = alias,
+                )
+            }
+        }
     }
 
     private fun registerOriginalCandidateCallback(
@@ -1369,6 +1409,7 @@ internal class AppleInternalCatalogResolver(
                         fallbackAliases = listOfNotNull(currentSong.alias),
                         genres = currentSong.genres,
                         artistIds = currentSong.artistIds,
+                        albumIds = currentSong.albumIds,
                     ),
                 )
                 return@queryById
@@ -1389,6 +1430,7 @@ internal class AppleInternalCatalogResolver(
                             fallbackAliases = fallbackAliases,
                             genres = fallbackGenres,
                             artistIds = currentSong?.artistIds.orEmpty(),
+                            albumIds = currentSong?.albumIds.orEmpty(),
                         ),
                     )
                     return
@@ -1411,6 +1453,9 @@ internal class AppleInternalCatalogResolver(
                                 artistIds = (
                                     currentSong?.artistIds.orEmpty() + song.artistIds
                                 ).distinct(),
+                                albumIds = (
+                                    currentSong?.albumIds.orEmpty() + song.albumIds
+                                ).distinct(),
                             ),
                         )
                     } else {
@@ -1429,6 +1474,7 @@ internal class AppleInternalCatalogResolver(
             fallbackAliases = listOfNotNull(song.alias),
             genres = song.genres,
             artistIds = song.artistIds,
+            albumIds = song.albumIds,
         )
         finishCatalogIdentity(mediaId, identity)
     }
@@ -1441,6 +1487,7 @@ internal class AppleInternalCatalogResolver(
                 fallbackAliases = (previous.fallbackAliases + identity.fallbackAliases).distinct(),
                 genres = (previous.genres + identity.genres).distinct(),
                 artistIds = (previous.artistIds + identity.artistIds).distinct(),
+                albumIds = (previous.albumIds + identity.albumIds).distinct(),
             )
         }
         val cacheable = isUsefulCatalogIdentity(merged)
@@ -1475,7 +1522,7 @@ internal class AppleInternalCatalogResolver(
         val queryParams = linkedMapOf(
             "ids" to mediaId,
             "platform" to "android",
-            "include[songs]" to "artists"
+            "include[songs]" to "artists,albums"
         )
         language?.let { queryParams["l"] = it }
         query(
@@ -1501,7 +1548,8 @@ internal class AppleInternalCatalogResolver(
             "platform" to "android",
         )
         if (entityType != LocalizedEntityType.ARTIST) {
-            queryParams["include[${entityType.path}]"] = "artists"
+            queryParams["include[${entityType.path}]"] =
+                if (entityType == LocalizedEntityType.SONG) "artists,albums" else "artists"
         }
         queryResponse(
             storefront = storefront,
@@ -1532,6 +1580,189 @@ internal class AppleInternalCatalogResolver(
         }
     }
 
+    private fun warmOriginalAlbumSequence(
+        anchorMediaId: String,
+        albumIds: List<String>,
+        language: String,
+        anchorAlias: Alias,
+    ) {
+        val normalizedAlbumIds = albumIds.asSequence()
+            .map(String::trim)
+            .filter { it.isNotEmpty() && it.all(Char::isDigit) }
+            .distinct()
+            .toList()
+        val targetLanguage = canonicalOriginalLanguage(language)
+        if (normalizedAlbumIds.isEmpty() || targetLanguage.isEmpty()) return
+        val requestKey = "${normalizedAlbumIds.sorted().joinToString(",")}:$targetLanguage"
+        val shouldStart = synchronized(originalAlbumSequenceInFlight) {
+            if (
+                requestKey in originalAlbumSequenceCompleted ||
+                !originalAlbumSequenceInFlight.add(requestKey)
+            ) false else true
+        }
+        if (!shouldStart) return
+
+        fun queryOriginalAlbum(
+            accountAlbumId: String,
+            accountTracks: List<CatalogSong>,
+            originalIndex: Int,
+        ) {
+            if (originalIndex >= normalizedAlbumIds.size) {
+                ProviderLogger.info(
+                    "Apple 原地区专辑序列替换跳过: accountAlbumId=$accountAlbumId, " +
+                        "originalAlbumIds=$normalizedAlbumIds, language=$targetLanguage, " +
+                        "account=${accountTracks.size}, anchor=$anchorMediaId"
+                )
+                finishOriginalAlbumSequenceWarm(requestKey, completed = false)
+                return
+            }
+            val originalAlbumId = normalizedAlbumIds[originalIndex]
+            queryAlbumTracks(originalAlbumId, language = targetLanguage) { originalTracks ->
+                val mappings = planOriginalAlbumSequence(
+                    accountTracks = accountTracks.map { it.toSequenceTrack() },
+                    originalTracks = originalTracks.map { it.toSequenceTrack() },
+                    anchorMediaId = anchorMediaId,
+                    anchorAlias = anchorAlias,
+                )
+                if (mappings == null) {
+                    queryOriginalAlbum(accountAlbumId, accountTracks, originalIndex + 1)
+                    return@queryAlbumTracks
+                }
+
+                mappings.forEach { mapping ->
+                    synchronized(cache) { cache[mapping.mediaId] = mapping.alias }
+                    persistentOriginalCache.put(
+                        originalSongCacheKey(mapping.mediaId),
+                        mapping.alias,
+                    )
+                    persistentOriginalCache.put(
+                        originalDirectEntityCacheKey(
+                            LocalizedEntityType.SONG,
+                            mapping.mediaId,
+                        ),
+                        mapping.alias,
+                    )
+                    MediaMetadataCache.updateOriginalMetadata(
+                        mediaId = mapping.mediaId,
+                        title = mapping.alias.title,
+                        artist = mapping.alias.artist,
+                        album = mapping.alias.album,
+                        resolved = true,
+                    )
+                }
+                ProviderLogger.info(
+                    "Apple 原地区专辑序列替换已缓存: accountAlbumId=$accountAlbumId, " +
+                        "originalAlbumId=$originalAlbumId, " +
+                        "language=$targetLanguage, tracks=${mappings.size}, anchor=$anchorMediaId"
+                )
+                finishOriginalAlbumSequenceWarm(requestKey, completed = true)
+            }
+        }
+
+        fun queryAccountAlbum(accountIndex: Int) {
+            if (accountIndex >= normalizedAlbumIds.size) {
+                finishOriginalAlbumSequenceWarm(requestKey, completed = false)
+                return
+            }
+            val accountAlbumId = normalizedAlbumIds[accountIndex]
+            queryAlbumTracks(
+                albumId = accountAlbumId,
+                language = targetLanguage,
+                storefront = accountStorefront,
+            ) { accountTracks ->
+                if (accountTracks.any { it.id == anchorMediaId }) {
+                    queryOriginalAlbum(accountAlbumId, accountTracks, originalIndex = 0)
+                } else {
+                    queryAccountAlbum(accountIndex + 1)
+                }
+            }
+        }
+        queryAccountAlbum(accountIndex = 0)
+    }
+
+    private fun finishOriginalAlbumSequenceWarm(requestKey: String, completed: Boolean) {
+        synchronized(originalAlbumSequenceInFlight) {
+            originalAlbumSequenceInFlight.remove(requestKey)
+            if (completed) originalAlbumSequenceCompleted.add(requestKey)
+        }
+    }
+
+    private fun queryAlbumTracks(
+        albumId: String,
+        language: String?,
+        storefront: String? = language?.let(::storefrontForLanguage),
+        onResult: (List<CatalogSong>) -> Unit,
+    ) {
+        val queryParams = linkedMapOf(
+            "platform" to "android",
+            "include[songs]" to "artists,albums",
+            "limit" to MAX_ALBUM_SEQUENCE_TRACKS.toString(),
+        )
+        language?.let { queryParams["l"] = it }
+        queryResponse(
+            storefront = storefront,
+            language = language,
+            description = "album-sequence=$albumId",
+            path = "albums/$albumId/tracks",
+            queryParams = queryParams,
+        ) { response ->
+            val tracks = runCatching {
+                response?.let {
+                    parseCatalogEntities(
+                        response = it,
+                        language = language ?: CURRENT_LANGUAGE,
+                        entityType = LocalizedEntityType.SONG,
+                    )
+                }.orEmpty().let(::completeCatalogAlbumTotals)
+            }.onFailure { error ->
+                ProviderLogger.error(
+                    "Apple 专辑轨道序列解析失败: albumId=$albumId, language=$language",
+                    error,
+                )
+            }.getOrDefault(emptyList())
+            tracks.forEach { track ->
+                ProviderLogger.debug(
+                    "Apple 专辑轨道位置: albumId=$albumId, id=${track.id}, " +
+                        "分段/位置=${track.discNumber}, 分段/总数=${track.discCount}, " +
+                        "轨道名=${track.alias.title}, 轨道名/位置=${track.trackNumber}, " +
+                        "轨道名/总数=${track.trackCount}"
+                )
+            }
+            if (tracks.any { it.trackNumber == null }) {
+                ProviderLogger.info(
+                    "Apple 原地区专辑位置匹配不可用: albumId=$albumId, " +
+                        "reason=track_position_missing"
+                )
+            }
+            onResult(tracks)
+        }
+    }
+
+    private fun completeCatalogAlbumTotals(tracks: List<CatalogSong>): List<CatalogSong> {
+        if (tracks.isEmpty()) return tracks
+        val discTotal = tracks.maxOf { it.discNumber ?: 1 }
+        val trackTotal = tracks.size
+        return tracks.map { track ->
+            track.copy(
+                discNumber = track.discNumber ?: 1,
+                discCount = track.discCount ?: discTotal,
+                trackCount = track.trackCount ?: trackTotal,
+            )
+        }
+    }
+
+    private fun CatalogSong.toSequenceTrack() = AlbumSequenceTrack(
+        mediaId = id.orEmpty(),
+        alias = alias,
+        isrc = isrc,
+        position = AlbumTrackPosition(
+            discPosition = discNumber ?: 1,
+            discTotal = discCount,
+            trackPosition = trackNumber,
+            trackTotal = trackCount,
+        ),
+    )
+
     private fun queryByIsrc(
         isrc: String,
         language: String,
@@ -1541,7 +1772,7 @@ internal class AppleInternalCatalogResolver(
             "filter[isrc]" to isrc,
             "l" to language,
             "platform" to "android",
-            "include[songs]" to "artists",
+            "include[songs]" to "artists,albums",
             "limit" to "1"
         )
         query(
@@ -2068,6 +2299,11 @@ internal class AppleInternalCatalogResolver(
         val relationshipArtists = relationshipArtistEntities.mapNotNull(CatalogArtist::name)
         val relationshipArtistIds = relationshipArtistEntities.mapNotNull(CatalogArtist::id)
             .distinct()
+        val relationshipAlbumIds = if (entityType == LocalizedEntityType.SONG) {
+            relationshipEntityIds(entity, "albums", "album")
+        } else {
+            emptyList()
+        }
         val artist = when (entityType) {
             LocalizedEntityType.ARTIST -> title
             else -> selectLocalizedArtistName(
@@ -2093,6 +2329,23 @@ internal class AppleInternalCatalogResolver(
         } else {
             null
         }
+        fun positiveInt(member: AppleMusicRuntimeMember): Int? = runCatching {
+            (AppleReflection.call(attributes, catalogMember(member)) as? Number)
+                ?.toInt()
+                ?.takeIf { it > 0 }
+        }.getOrNull()
+        val discNumber = if (entityType == LocalizedEntityType.SONG) {
+            positiveInt(AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_DISC_NUMBER_METHOD)
+        } else null
+        val discCount = if (entityType == LocalizedEntityType.SONG) {
+            positiveInt(AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_DISC_COUNT_METHOD)
+        } else null
+        val trackNumber = if (entityType == LocalizedEntityType.SONG) {
+            positiveInt(AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_TRACK_NUMBER_METHOD)
+        } else null
+        val trackCount = if (entityType == LocalizedEntityType.SONG) {
+            positiveInt(AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_TRACK_COUNT_METHOD)
+        } else null
         val genres = if (entityType != LocalizedEntityType.ARTIST) {
             runCatching {
                 collectionValues(
@@ -2130,8 +2383,40 @@ internal class AppleInternalCatalogResolver(
             isrc = isrc,
             genres = genres,
             artistIds = relationshipArtistIds,
+            albumIds = relationshipAlbumIds,
+            discNumber = discNumber,
+            discCount = discCount,
+            trackNumber = trackNumber,
+            trackCount = trackCount,
         )
     }
+
+    private fun relationshipEntityIds(entity: Any, vararg keys: String): List<String> =
+        runCatching {
+            @Suppress("UNCHECKED_CAST")
+            val relationships = AppleReflection.call(
+                entity,
+                catalogMember(AppleMusicRuntimeMember.CATALOG_ENTITY_RELATIONSHIPS_METHOD),
+            ) as? Map<String, Any?>
+            val relationship = keys.firstNotNullOfOrNull(relationships.orEmpty()::get)
+                ?: return@runCatching emptyList()
+            collectionValues(
+                AppleReflection.call(
+                    relationship,
+                    catalogMember(AppleMusicRuntimeMember.CATALOG_RELATIONSHIP_ENTITIES_METHOD),
+                ) ?: AppleReflection.call(
+                    relationship,
+                    catalogMember(AppleMusicRuntimeMember.CATALOG_RELATIONSHIP_DATA_METHOD),
+                )
+            ).mapNotNull { relatedEntity ->
+                (AppleReflection.call(
+                    relatedEntity,
+                    catalogMember(AppleMusicRuntimeMember.CATALOG_ENTITY_ID_METHOD),
+                ) as? String)
+                    ?.trim()
+                    ?.takeIf { it.isNotEmpty() && it.all(Char::isDigit) }
+            }.distinct()
+        }.getOrDefault(emptyList())
 
     private fun collectionValues(value: Any?): List<Any> = when (value) {
         is Array<*> -> value.filterNotNull()
@@ -2156,6 +2441,7 @@ internal class AppleInternalCatalogResolver(
         val fallbackAliases: List<Alias>,
         val genres: List<String>,
         val artistIds: List<String>,
+        val albumIds: List<String>,
     )
 
     private data class CatalogSong(
@@ -2164,6 +2450,11 @@ internal class AppleInternalCatalogResolver(
         val isrc: String?,
         val genres: List<String>,
         val artistIds: List<String>,
+        val albumIds: List<String>,
+        val discNumber: Int? = null,
+        val discCount: Int? = null,
+        val trackNumber: Int? = null,
+        val trackCount: Int? = null,
     )
 
     private data class CatalogArtist(
@@ -2207,6 +2498,25 @@ internal class AppleInternalCatalogResolver(
         val album: String = "",
     )
 
+    internal data class AlbumSequenceTrack(
+        val mediaId: String,
+        val alias: Alias,
+        val isrc: String?,
+        val position: AlbumTrackPosition? = null,
+    )
+
+    internal data class AlbumTrackPosition(
+        val discPosition: Int,
+        val discTotal: Int?,
+        val trackPosition: Int?,
+        val trackTotal: Int?,
+    )
+
+    internal data class AlbumSequenceMapping(
+        val mediaId: String,
+        val alias: Alias,
+    )
+
     data class OriginalResolution(
         val alias: Alias?,
         val language: String?,
@@ -2239,9 +2549,81 @@ internal class AppleInternalCatalogResolver(
         private const val LOCALIZED_ARTIST_ALIAS_CACHE_SIZE = 2_048
         private const val REQUEST_PRIORITY_CACHE_SIZE = 2_048
         private const val ORIGINAL_METADATA_CACHE_SCHEMA = "V2"
+        private const val MAX_ALBUM_SEQUENCE_TRACKS = 300
 
         internal fun isCoroutineSuspended(value: Any?): Boolean =
             value is Enum<*> && value.name == "COROUTINE_SUSPENDED"
+
+        internal fun planOriginalAlbumSequence(
+            accountTracks: List<AlbumSequenceTrack>,
+            originalTracks: List<AlbumSequenceTrack>,
+            anchorMediaId: String,
+            anchorAlias: Alias,
+        ): List<AlbumSequenceMapping>? {
+            if (
+                accountTracks.size !in 2..MAX_ALBUM_SEQUENCE_TRACKS ||
+                accountTracks.size != originalTracks.size ||
+                accountTracks.any { it.mediaId.isBlank() } ||
+                accountTracks.map(AlbumSequenceTrack::mediaId).distinct().size != accountTracks.size
+            ) return null
+            val accountByPosition = completeAlbumPositions(accountTracks) ?: return null
+            val originalByPosition = completeAlbumPositions(originalTracks) ?: return null
+            if (accountByPosition.keys != originalByPosition.keys) return null
+            val anchorPosition = accountByPosition.entries
+                .firstOrNull { it.value.mediaId == anchorMediaId }
+                ?.key ?: return null
+            val originalAnchor = originalByPosition[anchorPosition] ?: return null
+            if (normalize(originalAnchor.alias.title) != normalize(anchorAlias.title)) return null
+            if (
+                anchorAlias.album.isNotBlank() &&
+                originalAnchor.alias.album.isNotBlank() &&
+                normalize(originalAnchor.alias.album) != normalize(anchorAlias.album)
+            ) return null
+
+            val pairedTracks = accountByPosition.keys.sortedWith(
+                compareBy<AlbumPositionKey> { it.disc }.thenBy { it.track }
+            ).map { key ->
+                accountByPosition.getValue(key) to originalByPosition.getValue(key)
+            }
+            if (originalTracks.any { it.alias.title.isBlank() }) return null
+
+            return pairedTracks.map { (account, original) ->
+                AlbumSequenceMapping(
+                    mediaId = account.mediaId,
+                    alias = original.alias,
+                )
+            }
+        }
+
+        private fun completeAlbumPositions(
+            tracks: List<AlbumSequenceTrack>,
+        ): Map<AlbumPositionKey, AlbumSequenceTrack>? {
+            val raw = tracks.map { track ->
+                val position = track.position ?: return null
+                val trackPosition = position.trackPosition?.takeIf { it > 0 } ?: return null
+                if (position.discPosition <= 0) return null
+                Triple(
+                    AlbumPositionKey(position.discPosition, trackPosition),
+                    position,
+                    track,
+                )
+            }
+            if (raw.map { it.first }.distinct().size != tracks.size) return null
+            val derivedDiscTotal = raw.maxOf { it.second.discPosition }
+            val declaredDiscTotals = raw.mapNotNull { it.second.discTotal }.distinct()
+            if (
+                declaredDiscTotals.size > 1 ||
+                declaredDiscTotals.singleOrNull()?.let { it != derivedDiscTotal } == true
+            ) return null
+            val declaredTrackTotals = raw.mapNotNull { it.second.trackTotal }.distinct()
+            if (
+                declaredTrackTotals.size > 1 ||
+                declaredTrackTotals.singleOrNull()?.let { it != tracks.size } == true
+            ) return null
+            return raw.associate { (key, _, track) -> key to track }
+        }
+
+        private data class AlbumPositionKey(val disc: Int, val track: Int)
 
         internal fun originalSongCacheKey(mediaId: String): String =
             "$ORIGINAL_METADATA_CACHE_SCHEMA:VERIFIED_SONG:${mediaId.trim()}"

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleMusicHookProfiles.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleMusicHookProfiles.kt
@@ -284,6 +284,10 @@ internal enum class AppleMusicRuntimeMember {
     CATALOG_ATTRIBUTES_NAME_METHOD,
     CATALOG_ATTRIBUTES_ARTIST_NAME_METHOD,
     CATALOG_ATTRIBUTES_ALBUM_NAME_METHOD,
+    CATALOG_ATTRIBUTES_DISC_NUMBER_METHOD,
+    CATALOG_ATTRIBUTES_DISC_COUNT_METHOD,
+    CATALOG_ATTRIBUTES_TRACK_NUMBER_METHOD,
+    CATALOG_ATTRIBUTES_TRACK_COUNT_METHOD,
     CATALOG_ATTRIBUTES_ARTIST_ID_METHOD,
     CATALOG_ATTRIBUTES_ARTIST_ADAM_ID_METHOD,
     CATALOG_ATTRIBUTES_ARTIST_STORE_ID_METHOD,
@@ -834,6 +838,14 @@ internal object AppleMusicHookProfiles {
                         "getArtistName",
                     AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_ALBUM_NAME_METHOD to
                         "getAlbumName",
+                    AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_DISC_NUMBER_METHOD to
+                        "getDiscNumber",
+                    AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_DISC_COUNT_METHOD to
+                        "getDiscCount",
+                    AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_TRACK_NUMBER_METHOD to
+                        "getTrackNumber",
+                    AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_TRACK_COUNT_METHOD to
+                        "getTrackCount",
                     AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_ARTIST_ID_METHOD to "getArtistId",
                     AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_ARTIST_ADAM_ID_METHOD to
                         "getArtistAdamId",

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/MediaMetadataCache.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/MediaMetadataCache.kt
@@ -20,8 +20,10 @@ object MediaMetadataCache {
         val current = metadataCache[metadata.id]
         metadataCache[metadata.id] = metadata.copy(
             genre = mergeGenres(current?.genre, listOfNotNull(metadata.genre)),
+            album = metadata.album ?: current?.album,
             originalTitle = metadata.originalTitle ?: current?.originalTitle,
             originalArtist = metadata.originalArtist ?: current?.originalArtist,
+            originalAlbum = metadata.originalAlbum ?: current?.originalAlbum,
             originalMetadataResolved = metadata.originalMetadataResolved ||
                 current?.originalMetadataResolved == true,
         )
@@ -35,12 +37,14 @@ object MediaMetadataCache {
         mediaId: String,
         title: String?,
         artist: String?,
+        album: String? = null,
         resolved: Boolean = true,
     ): Metadata? {
         val current = metadataCache[mediaId] ?: return null
         val updated = current.copy(
             originalTitle = title,
             originalArtist = artist,
+            originalAlbum = album ?: current.originalAlbum,
             originalMetadataResolved = resolved,
         )
         metadataCache[mediaId] = updated
@@ -48,11 +52,17 @@ object MediaMetadataCache {
     }
 
     @Synchronized
-    fun updateDisplayMetadata(mediaId: String, title: String?, artist: String?): Metadata? {
+    fun updateDisplayMetadata(
+        mediaId: String,
+        title: String?,
+        artist: String?,
+        album: String? = null,
+    ): Metadata? {
         val current = metadataCache[mediaId] ?: return null
         val updated = current.copy(
             title = title?.takeIf(String::isNotBlank) ?: current.title,
             artist = artist?.takeIf(String::isNotBlank) ?: current.artist,
+            album = album?.takeIf(String::isNotBlank) ?: current.album,
         )
         metadataCache[mediaId] = updated
         return updated
@@ -84,8 +94,10 @@ object MediaMetadataCache {
         val title: String?,
         val artist: String?,
         val genre: String?,
+        val album: String? = null,
         val originalTitle: String? = null,
         val originalArtist: String? = null,
+        val originalAlbum: String? = null,
         val originalMetadataResolved: Boolean = false,
         val duration: Long,
         val queueId: Long

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/SongRepository.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/SongRepository.kt
@@ -68,16 +68,20 @@ object SongRepository {
         val metadata = adamId?.let(MediaMetadataCache::getMetadataById) ?: return@apply
         name = metadata.title
         artist = metadata.artist
+        album = metadata.album
         genre = metadata.genre
         originalTitle = metadata.originalTitle
         originalArtist = metadata.originalArtist
+        originalAlbum = metadata.originalAlbum
         originalMetadataResolved = metadata.originalMetadataResolved
     }
 
     private fun MediaMetadataCache.Metadata.toLyricMetadata() = lyricMetadataOf(
         LyricMetadataKeys.APPLE_CATALOG_GENRE to genre,
+        LyricMetadataKeys.APPLE_ALBUM to album,
         LyricMetadataKeys.APPLE_ORIGINAL_TITLE to originalTitle,
         LyricMetadataKeys.APPLE_ORIGINAL_ARTIST to originalArtist,
+        LyricMetadataKeys.APPLE_ORIGINAL_ALBUM to originalAlbum,
         LyricMetadataKeys.APPLE_ORIGINAL_METADATA_RESOLVED to
             originalMetadataResolved.toString()
     )

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/AppleMetadataOverrideApplicationCoordinator.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/AppleMetadataOverrideApplicationCoordinator.kt
@@ -129,7 +129,12 @@ internal class AppleMetadataOverrideApplicationCoordinator(
         if (playbackMetadataCoordinator.currentMetadataId() == mediaId) {
             metadataStore.updateCurrentPlaybackOverride(effectiveAlias)
         }
-        MediaMetadataCache.updateDisplayMetadata(mediaId, effectiveAlias.title, effectiveAlias.artist)
+        MediaMetadataCache.updateDisplayMetadata(
+            mediaId = mediaId,
+            title = effectiveAlias.title,
+            artist = effectiveAlias.artist,
+            album = effectiveAlias.album,
+        )
         PlaybackManager.onCatalogMetadataResolved(mediaId)
         val listenNowDirectBindingTargets = if (
             !allowModelRefresh && listenNowHooks.hasDataBindingRefs(mediaId)

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/ApplePlaybackMetadataCoordinator.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/ApplePlaybackMetadataCoordinator.kt
@@ -361,6 +361,7 @@ internal class ApplePlaybackMetadataCoordinator(
                     mediaId = metadata.id,
                     title = alias?.title,
                     artist = alias?.artist,
+                    album = alias?.album,
                     resolved = true,
                 )
                 if (alias == null) {

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/ApplePlaybackMetadataCoordinator.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/metadata/ApplePlaybackMetadataCoordinator.kt
@@ -116,6 +116,11 @@ internal class ApplePlaybackMetadataCoordinator(
                 playbackMember(AppleMusicRuntimeMember.PLAYBACK_QUEUE_ITEM_ITEM_METHOD),
             ) ?: return@runCatching
             val mediaId = mediaItemId(mediaItem) ?: return@runCatching
+            val queueAlbum = readAlbumName(mediaItem)
+            val aliasAlbum = host.effectiveMetadataAlias(mediaId)
+                ?.album
+                ?.trim()
+                ?.takeIf(String::isNotEmpty)
             val languageSelection = host.configuredContentUiLanguage()
             val overrideAccountLanguage = host.shouldOverrideAccountLanguage(languageSelection)
 
@@ -135,6 +140,7 @@ internal class ApplePlaybackMetadataCoordinator(
                     mediaItem,
                     playbackMember(AppleMusicRuntimeMember.PLAYBACK_MEDIA_ITEM_GENRE_NAME_METHOD),
                 ) as? String,
+                album = queueAlbum ?: aliasAlbum,
                 duration = AppleReflection.call(
                     mediaItem,
                     playbackMember(AppleMusicRuntimeMember.PLAYBACK_MEDIA_ITEM_DURATION_METHOD),
@@ -152,7 +158,9 @@ internal class ApplePlaybackMetadataCoordinator(
             MediaMetadataCache.put(metadata)
             ProviderLogger.debug(
                 "歌曲元数据已更新：source=$source, id=${metadata.id}, " +
-                    "queueId=${metadata.queueId}, 标题=${metadata.title}"
+                    "queueId=${metadata.queueId}, 标题=${metadata.title}, " +
+                    "专辑=${metadata.album}, 专辑来源=" +
+                    if (queueAlbum != null) "queue" else if (aliasAlbum != null) "alias" else "none"
             )
             if (publishAsCurrent) {
                 val previousCurrentId = currentMediaId
@@ -186,6 +194,17 @@ internal class ApplePlaybackMetadataCoordinator(
         }.onFailure {
             ProviderLogger.error("歌曲元数据解析异常：source=$source", it)
         }
+    }
+
+    /** Queue media items differ across Apple Music builds; probe the stable album accessors. */
+    private fun readAlbumName(mediaItem: Any): String? = listOf(
+        "getAlbumName",
+        "getAlbum",
+        "getCollectionName",
+    ).firstNotNullOfOrNull { methodName ->
+        runCatching {
+            AppleReflection.call(mediaItem, methodName) as? String
+        }.getOrNull()?.trim()?.takeIf(String::isNotEmpty)
     }
 
     fun resolveOriginalMetadataOnDemand(mediaId: String) {

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/model/AppleSong.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/model/AppleSong.kt
@@ -12,9 +12,11 @@ import kotlinx.serialization.Serializable
 data class AppleSong(
     var name: String? = null,
     var artist: String? = null,
+    var album: String? = null,
     var genre: String? = null,
     var originalTitle: String? = null,
     var originalArtist: String? = null,
+    var originalAlbum: String? = null,
     var originalMetadataResolved: Boolean = false,
     var adamId: String? = null,
     var pronunciationLanguages: MutableList<String> = mutableListOf(),

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/parser/AppleSongParser.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/parser/AppleSongParser.kt
@@ -46,9 +46,11 @@ object AppleSongParser {
                     ?.let { metadata ->
                         name = metadata.title
                         artist = metadata.artist
+                        album = metadata.album
                         genre = metadata.genre
                         originalTitle = metadata.originalTitle
                         originalArtist = metadata.originalArtist
+                        originalAlbum = metadata.originalAlbum
                     }
             }
         }

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/util/AppleSongMapper.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/util/AppleSongMapper.kt
@@ -26,6 +26,9 @@ object AppleSongMapper {
             song.genre?.takeIf { it.isNotBlank() }?.let {
                 add(LyricMetadataKeys.APPLE_CATALOG_GENRE to it)
             }
+            song.album?.takeIf { it.isNotBlank() }?.let {
+                add(LyricMetadataKeys.APPLE_ALBUM to it)
+            }
             song.pronunciationLanguages
                 .map(String::trim)
                 .filter(String::isNotEmpty)
@@ -40,6 +43,9 @@ object AppleSongMapper {
             }
             song.originalArtist?.takeIf { it.isNotBlank() }?.let {
                 add(LyricMetadataKeys.APPLE_ORIGINAL_ARTIST to it)
+            }
+            song.originalAlbum?.takeIf { it.isNotBlank() }?.let {
+                add(LyricMetadataKeys.APPLE_ORIGINAL_ALBUM to it)
             }
             if (song.originalMetadataResolved) {
                 add(LyricMetadataKeys.APPLE_ORIGINAL_METADATA_RESOLVED to "true")

--- a/app/src/main/java/io/github/proify/lyricon/central/provider/player/PlayerBinder.kt
+++ b/app/src/main/java/io/github/proify/lyricon/central/provider/player/PlayerBinder.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.decodeFromStream
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 internal class PlayerBinder(
     info: ProviderInfo,
@@ -39,6 +40,7 @@ internal class PlayerBinder(
     private val recorder = PlayerRecorder(info)
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private val closed = AtomicBoolean(false)
+    private val songUpdateGeneration = AtomicLong(0L)
     private val isState2Enabled = AtomicBoolean(false)
     private val closeMutex = Mutex()
     private val positionMemory = PositionMemoryBridge(info)
@@ -101,6 +103,7 @@ internal class PlayerBinder(
     override fun setSong(bytes: ByteArray?) {
         if (closed.get()) return
 
+        val generation = songUpdateGeneration.incrementAndGet()
         scope.launch {
             val song = bytes?.let {
                 runCatching {
@@ -114,6 +117,7 @@ internal class PlayerBinder(
             }
 
             val normalized = song?.normalize()
+            if (closed.get() || generation != songUpdateGeneration.get()) return@launch
             recorder.song = normalized
             playerEvents.safeNotify { onSongChanged(recorder, normalized) }
         }

--- a/app/src/test/java/com/juren233/hyperlyricsenhanced/online/OnlineLyricTargeterTest.kt
+++ b/app/src/test/java/com/juren233/hyperlyricsenhanced/online/OnlineLyricTargeterTest.kt
@@ -169,6 +169,18 @@ class OnlineLyricTargeterTest {
     }
 
     @Test
+    fun `normalizes catalog punctuation before matching`() {
+        assertEquals(
+            "超かぐや姫",
+            OnlineLyricTargeter.normalizeMatchText("超かぐや姫！"),
+        )
+        assertEquals(
+            OnlineLyricTargeter.normalizeMatchText("超かぐや姫!"),
+            OnlineLyricTargeter.normalizeMatchText("超かぐや姫！"),
+        )
+    }
+
+    @Test
     fun `rejects a title only candidate even when its numeric score is high`() {
         assertEquals(
             false,

--- a/app/src/test/java/com/juren233/hyperlyricsenhanced/online/OnlineLyricTargeterTest.kt
+++ b/app/src/test/java/com/juren233/hyperlyricsenhanced/online/OnlineLyricTargeterTest.kt
@@ -72,6 +72,21 @@ class OnlineLyricTargeterTest {
     }
 
     @Test
+    fun `retries when only Apple original album differs`() {
+        assertEquals(
+            true,
+            OnlineLyricTargeter.shouldRetryWithOriginalMetadata(
+                title = "Reply",
+                artist = "kz",
+                originalTitle = "Reply",
+                originalArtist = "kz",
+                album = "Cosmic Princess Kaguya!",
+                originalAlbum = "超かぐや姫!",
+            ),
+        )
+    }
+
+    @Test
     fun `searches Apple original metadata first when correction is enabled`() {
         assertEquals(
             listOf(true, false),
@@ -101,6 +116,106 @@ class OnlineLyricTargeterTest {
         assertEquals(
             "藤井風",
             OnlineLyricTargeter.compactWhitespace("藤井 風")
+        )
+    }
+
+    @Test
+    fun `builds progressive searches for character song credits`() {
+        assertEquals(
+            listOf(
+                "Reply kz & かぐや(cv.夏吉ゆうこ)",
+                "Reply kz",
+                "Reply かぐや",
+                "Reply",
+            ),
+            OnlineLyricTargeter.resolveSearchKeywords(
+                title = "Reply",
+                artist = "kz & かぐや(cv.夏吉ゆうこ)",
+            ),
+        )
+    }
+
+    @Test
+    fun `deduplicates progressive searches for a simple artist`() {
+        assertEquals(
+            listOf("Remember yuigot", "Remember"),
+            OnlineLyricTargeter.resolveSearchKeywords("Remember", "yuigot"),
+        )
+    }
+
+    @Test
+    fun `includes album in progressive searches without losing broad fallbacks`() {
+        assertEquals(
+            listOf(
+                "Reply kz Cosmic Princess Kaguya!",
+                "Reply kz",
+                "Reply Cosmic Princess Kaguya!",
+                "Reply",
+            ),
+            OnlineLyricTargeter.resolveSearchKeywords(
+                title = "Reply",
+                artist = "kz",
+                album = "Cosmic Princess Kaguya!",
+            ),
+        )
+    }
+
+    @Test
+    fun `normalizes full width album punctuation`() {
+        assertEquals(
+            "超かぐや姫!",
+            OnlineLyricTargeter.normalizeWidth("超かぐや姫！"),
+        )
+    }
+
+    @Test
+    fun `rejects a title only candidate even when its numeric score is high`() {
+        assertEquals(
+            false,
+            OnlineLyricTargeter.CandidateMatch(
+                total = 105,
+                titleMatched = true,
+                artistMatched = false,
+                albumMatched = false,
+            ).isEligible,
+        )
+    }
+
+    @Test
+    fun `accepts title with either artist or album identity`() {
+        assertEquals(
+            true,
+            OnlineLyricTargeter.CandidateMatch(
+                total = 80,
+                titleMatched = true,
+                artistMatched = true,
+                albumMatched = false,
+            ).isEligible,
+        )
+        assertEquals(
+            true,
+            OnlineLyricTargeter.CandidateMatch(
+                total = 80,
+                titleMatched = true,
+                artistMatched = false,
+                albumMatched = true,
+            ).isEligible,
+        )
+    }
+
+    @Test
+    fun `strips every supported credit bracket without breaking keyword generation`() {
+        assertEquals(
+            listOf(
+                "Reply kz & Kaguya(cv.Yuko) [Character] {Live}",
+                "Reply kz",
+                "Reply Kaguya",
+                "Reply",
+            ),
+            OnlineLyricTargeter.resolveSearchKeywords(
+                title = "Reply",
+                artist = "kz & Kaguya(cv.Yuko) [Character] {Live}",
+            ),
         )
     }
 

--- a/app/src/test/java/com/juren233/hyperlyricsenhanced/root/source/AppleOnlineTranslationRequestPolicyTest.kt
+++ b/app/src/test/java/com/juren233/hyperlyricsenhanced/root/source/AppleOnlineTranslationRequestPolicyTest.kt
@@ -3,6 +3,7 @@ package com.juren233.hyperlyricsenhanced.root.source
 import com.juren233.hyperlyricsenhanced.common.lyric.LyricMetadataKeys
 import com.juren233.hyperlyricsenhanced.lyric.model.Song
 import com.juren233.hyperlyricsenhanced.lyric.model.lyricMetadataOf
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
@@ -10,13 +11,32 @@ import org.junit.Test
 
 class AppleOnlineTranslationRequestPolicyTest {
     @Test
-    fun `original metadata request does not block current metadata lookup`() {
+    fun `original metadata request waits before online lookup`() {
         val plan = AppleOnlineTranslationRequestPolicy.originalMetadataLookupPlan(
             shouldRequestOriginalMetadata = true
         )
 
         assertTrue(plan.requestOriginalMetadata)
-        assertFalse(plan.waitForResult)
+        assertTrue(plan.waitForResult)
+    }
+
+    @Test
+    fun `resolved Apple replacement becomes current matching metadata`() {
+        val localized = song(
+            originalTitle = "Reply",
+            originalArtist = "kz, かぐや(cv.夏吉ゆうこ)",
+            originalAlbum = "超かぐや姫!",
+            resolved = true,
+        )
+
+        val replaced = AppleOnlineTranslationRequestPolicy.applyResolvedReplacement(
+            localized,
+            enabled = true,
+        )!!
+
+        assertEquals("Reply", replaced.name)
+        assertEquals("kz, かぐや(cv.夏吉ゆうこ)", replaced.artist)
+        assertEquals("超かぐや姫!", AppleOnlineTranslationRequestPolicy.effectiveAlbum(replaced))
     }
 
     @Test
@@ -52,16 +72,20 @@ class AppleOnlineTranslationRequestPolicyTest {
 
     private fun song(
         originalTitle: String? = null,
-        originalArtist: String? = null
+        originalArtist: String? = null,
+        originalAlbum: String? = null,
+        resolved: Boolean = false,
     ): Song = Song(
         id = "1882935962",
         name = "Michi Teyu Ku (Overflowing)",
         artist = "Fujii Kaze",
         duration = 315_000,
-        metadata = if (originalTitle != null || originalArtist != null) {
+        metadata = if (originalTitle != null || originalArtist != null || originalAlbum != null) {
             lyricMetadataOf(
                 LyricMetadataKeys.APPLE_ORIGINAL_TITLE to originalTitle,
-                LyricMetadataKeys.APPLE_ORIGINAL_ARTIST to originalArtist
+                LyricMetadataKeys.APPLE_ORIGINAL_ARTIST to originalArtist,
+                LyricMetadataKeys.APPLE_ORIGINAL_ALBUM to originalAlbum,
+                LyricMetadataKeys.APPLE_ORIGINAL_METADATA_RESOLVED to resolved.toString(),
             )
         } else {
             null

--- a/app/src/test/java/com/juren233/hyperlyricsenhanced/root/source/AppleOnlineTranslationRequestPolicyTest.kt
+++ b/app/src/test/java/com/juren233/hyperlyricsenhanced/root/source/AppleOnlineTranslationRequestPolicyTest.kt
@@ -70,6 +70,36 @@ class AppleOnlineTranslationRequestPolicyTest {
         )
     }
 
+    @Test
+    fun `album arrival changes the matching metadata and translation attempt`() {
+        val before = song()
+        val after = song(originalAlbum = "超かぐや姫!")
+
+        assertTrue(
+            AppleOnlineTranslationRequestPolicy.matchingMetadataChanged(before, after)
+        )
+        assertNotEquals(
+            AppleOnlineTranslationRequestPolicy.attemptKey(before),
+            AppleOnlineTranslationRequestPolicy.attemptKey(after)
+        )
+    }
+
+    @Test
+    fun `defers lookup while the replacement payload has no album`() {
+        assertTrue(
+            AppleOnlineTranslationRequestPolicy.shouldWaitForMatchingAlbum(
+                song(),
+                preferOriginalMetadata = true,
+            )
+        )
+        assertFalse(
+            AppleOnlineTranslationRequestPolicy.shouldWaitForMatchingAlbum(
+                song(originalAlbum = "超かぐや姫!", resolved = true),
+                preferOriginalMetadata = true,
+            )
+        )
+    }
+
     private fun song(
         originalTitle: String? = null,
         originalArtist: String? = null,

--- a/app/src/test/java/com/juren233/hyperlyricsenhanced/root/source/OnlineTranslationMatcherTest.kt
+++ b/app/src/test/java/com/juren233/hyperlyricsenhanced/root/source/OnlineTranslationMatcherTest.kt
@@ -581,7 +581,7 @@ class OnlineTranslationMatcherTest {
     }
 
     @Test
-    fun `does not split an unstructured translation at arbitrary characters`() {
+    fun `repeats an unstructured combined translation instead of leaving split lines blank`() {
         val song = Song(
             name = "Song",
             lyrics = listOf(
@@ -601,9 +601,12 @@ class OnlineTranslationMatcherTest {
             )
         )
 
-        assertEquals(1, result.matchedCount)
+        assertEquals(2, result.matchedCount)
         assertEquals(
-            listOf(null, "这是一句没有任何可靠分隔符的中文译文"),
+            listOf(
+                "这是一句没有任何可靠分隔符的中文译文",
+                "这是一句没有任何可靠分隔符的中文译文",
+            ),
             result.song.lyrics?.map { it.translation }
         )
     }
@@ -630,7 +633,7 @@ class OnlineTranslationMatcherTest {
     }
 
     @Test
-    fun `does not split a Chinese translation at spaces inside an English name`() {
+    fun `keeps a Chinese translation with an English name complete on split lines`() {
         val song = Song(
             name = "I Like It",
             lyrics = listOf(
@@ -650,7 +653,43 @@ class OnlineTranslationMatcherTest {
             )
         )
 
-        assertEquals(listOf(null, null), result.song.lyrics?.map { it.translation })
+        assertEquals(
+            listOf(
+                "家喻户晓的Cardi B 成功就像有氧运动一样简单",
+                "家喻户晓的Cardi B 成功就像有氧运动一样简单",
+            ),
+            result.song.lyrics?.map { it.translation },
+        )
+    }
+
+    @Test
+    fun `matches an online line split into more than three Apple lines`() {
+        val song = Song(
+            name = "Song",
+            lyrics = listOf(
+                RichLyricLine(begin = 1_000L, end = 2_000L, text = "One"),
+                RichLyricLine(begin = 2_000L, end = 3_000L, text = "two"),
+                RichLyricLine(begin = 3_000L, end = 4_000L, text = "three"),
+                RichLyricLine(begin = 4_000L, end = 5_000L, text = "four"),
+            ),
+        )
+
+        val result = OnlineTranslationMatcher.apply(
+            song,
+            listOf(
+                LrcLine(
+                    1_000L,
+                    "One two three four",
+                    "这是没有分隔标记的完整译文",
+                ),
+            ),
+        )
+
+        assertEquals(4, result.matchedCount)
+        assertEquals(
+            List(4) { "这是没有分隔标记的完整译文" },
+            result.song.lyrics?.map { it.translation },
+        )
     }
 
     @Test

--- a/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolverTest.kt
+++ b/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/AppleInternalCatalogResolverTest.kt
@@ -991,4 +991,144 @@ class AppleInternalCatalogResolverTest {
             AppleInternalCatalogResolver.normalizedArtistNameKey("周杰伦、梁静茹"),
         )
     }
+
+    @Test
+    fun `maps a confirmed original album to account song ids by track sequence`() {
+        val account = listOf(
+            sequenceTrack("101", "Localized One", "ISRC1", trackPosition = 1),
+            sequenceTrack("102", "Localized Two", "ISRC2", trackPosition = 2),
+            sequenceTrack("103", "Localized Three", "ISRC3", trackPosition = 3),
+        )
+        val original = listOf(
+            sequenceTrack("201", "原曲一", "ISRC1", album = "原專輯", trackPosition = 1),
+            sequenceTrack("202", "原曲二", "ISRC2", album = "原專輯", trackPosition = 2),
+            sequenceTrack("203", "原曲三", "ISRC3", album = "原專輯", trackPosition = 3),
+        )
+
+        val mappings = AppleInternalCatalogResolver.planOriginalAlbumSequence(
+            accountTracks = account,
+            originalTracks = original,
+            anchorMediaId = "102",
+            anchorAlias = AppleInternalCatalogResolver.Alias(
+                title = "原曲二",
+                artist = "原歌手",
+                album = "原專輯",
+                language = "zh-Hant",
+            ),
+        )
+
+        assertEquals(listOf("101", "102", "103"), mappings?.map { it.mediaId })
+        assertEquals(listOf("原曲一", "原曲二", "原曲三"), mappings?.map { it.alias.title })
+    }
+
+    @Test
+    fun `accepts position confirmed album replacement when regional ISRC values differ`() {
+        val account = listOf(
+            sequenceTrack("101", "Localized One", "ISRC1", trackPosition = 1),
+            sequenceTrack("102", "Localized Two", "ISRC2", trackPosition = 2),
+            sequenceTrack("103", "Localized Three", "ISRC3", trackPosition = 3),
+        )
+        val shiftedOriginal = listOf(
+            sequenceTrack("201", "原曲二", "ISRC2", album = "原專輯", trackPosition = 1),
+            sequenceTrack("202", "原曲一", "ISRC1", album = "原專輯", trackPosition = 2),
+            sequenceTrack("203", "原曲三", "ISRC3", album = "原專輯", trackPosition = 3),
+        )
+
+        val mappings = AppleInternalCatalogResolver.planOriginalAlbumSequence(
+                accountTracks = account,
+                originalTracks = shiftedOriginal,
+                anchorMediaId = "102",
+                anchorAlias = AppleInternalCatalogResolver.Alias(
+                    title = "原曲一",
+                    artist = "原歌手",
+                    album = "原專輯",
+                    language = "zh-Hant",
+                ),
+            )
+
+        assertEquals(listOf("101", "102", "103"), mappings?.map { it.mediaId })
+        assertEquals(listOf("原曲二", "原曲一", "原曲三"), mappings?.map { it.alias.title })
+    }
+
+    @Test
+    fun `maps album by disc and track position when API arrays are shuffled`() {
+        val account = listOf(
+            sequenceTrack("102", "Localized Two", "ISRC2", trackPosition = 2),
+            sequenceTrack("101", "Localized One", "ISRC1", trackPosition = 1),
+            sequenceTrack("103", "Localized Three", "ISRC3", trackPosition = 3),
+        )
+        val original = listOf(
+            sequenceTrack("203", "原曲三", "ISRC3", "原專輯", trackPosition = 3),
+            sequenceTrack("201", "原曲一", "ISRC1", "原專輯", trackPosition = 1),
+            sequenceTrack("202", "原曲二", "ISRC2", "原專輯", trackPosition = 2),
+        )
+
+        val mappings = AppleInternalCatalogResolver.planOriginalAlbumSequence(
+            accountTracks = account,
+            originalTracks = original,
+            anchorMediaId = "102",
+            anchorAlias = AppleInternalCatalogResolver.Alias(
+                title = "原曲二",
+                artist = "原歌手",
+                album = "原專輯",
+                language = "zh-Hant",
+            ),
+        )
+
+        assertEquals(listOf("101", "102", "103"), mappings?.map { it.mediaId })
+        assertEquals(listOf("原曲一", "原曲二", "原曲三"), mappings?.map { it.alias.title })
+    }
+
+    @Test
+    fun `rejects album replacement when position totals conflict`() {
+        val account = listOf(
+            sequenceTrack("101", "Localized One", "ISRC1", trackPosition = 1),
+            sequenceTrack("102", "Localized Two", "ISRC2", trackPosition = 2),
+            sequenceTrack("103", "Localized Three", "ISRC3", trackPosition = 3),
+        )
+        val invalidOriginal = listOf(
+            sequenceTrack("201", "原曲一", "ISRC1", "原專輯", 1, trackTotal = 13),
+            sequenceTrack("202", "原曲二", "ISRC2", "原專輯", 2, trackTotal = 13),
+            sequenceTrack("203", "原曲三", "ISRC3", "原專輯", 3, trackTotal = 13),
+        )
+
+        assertEquals(
+            null,
+            AppleInternalCatalogResolver.planOriginalAlbumSequence(
+                accountTracks = account,
+                originalTracks = invalidOriginal,
+                anchorMediaId = "102",
+                anchorAlias = AppleInternalCatalogResolver.Alias(
+                    title = "原曲二",
+                    artist = "原歌手",
+                    album = "原專輯",
+                    language = "zh-Hant",
+                ),
+            ),
+        )
+    }
+
+    private fun sequenceTrack(
+        id: String,
+        title: String,
+        isrc: String,
+        album: String = "Localized Album",
+        trackPosition: Int,
+        trackTotal: Int = 3,
+    ) = AppleInternalCatalogResolver.AlbumSequenceTrack(
+        mediaId = id,
+        alias = AppleInternalCatalogResolver.Alias(
+            title = title,
+            artist = "Artist",
+            album = album,
+            language = "current",
+        ),
+        isrc = isrc,
+        position = AppleInternalCatalogResolver.AlbumTrackPosition(
+            discPosition = 1,
+            discTotal = 1,
+            trackPosition = trackPosition,
+            trackTotal = trackTotal,
+        ),
+    )
 }

--- a/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/AppleMusicHookProfilesTest.kt
+++ b/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/AppleMusicHookProfilesTest.kt
@@ -701,6 +701,10 @@ class AppleMusicHookProfilesTest {
                 AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_NAME_METHOD to "getName",
                 AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_ARTIST_NAME_METHOD to "getArtistName",
                 AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_ALBUM_NAME_METHOD to "getAlbumName",
+                AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_DISC_NUMBER_METHOD to "getDiscNumber",
+                AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_DISC_COUNT_METHOD to "getDiscCount",
+                AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_TRACK_NUMBER_METHOD to "getTrackNumber",
+                AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_TRACK_COUNT_METHOD to "getTrackCount",
                 AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_ARTIST_ID_METHOD to "getArtistId",
                 AppleMusicRuntimeMember.CATALOG_ATTRIBUTES_ARTIST_ADAM_ID_METHOD to
                     "getArtistAdamId",

--- a/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/MediaMetadataCacheTest.kt
+++ b/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/MediaMetadataCacheTest.kt
@@ -34,6 +34,39 @@ class MediaMetadataCacheTest {
         )
     }
 
+    @Test
+    fun `original album survives later metadata updates`() {
+        val mediaId = "media-metadata-cache-original-album"
+        MediaMetadataCache.put(metadata(mediaId, genre = "J-Pop"))
+        MediaMetadataCache.updateOriginalMetadata(
+            mediaId = mediaId,
+            title = "Reply",
+            artist = "kz, かぐや(cv.夏吉ゆうこ)",
+            album = "超かぐや姫!",
+        )
+        MediaMetadataCache.put(metadata(mediaId, genre = null))
+
+        assertEquals(
+            "超かぐや姫!",
+            MediaMetadataCache.getMetadataById(mediaId)?.originalAlbum,
+        )
+    }
+
+    @Test
+    fun `display replacement updates current album`() {
+        val mediaId = "media-metadata-cache-display-album"
+        MediaMetadataCache.put(metadata(mediaId, genre = "J-Pop"))
+
+        MediaMetadataCache.updateDisplayMetadata(
+            mediaId = mediaId,
+            title = "Reply",
+            artist = "kz, かぐや(cv.夏吉ゆうこ)",
+            album = "超かぐや姫!",
+        )
+
+        assertEquals("超かぐや姫!", MediaMetadataCache.getMetadataById(mediaId)?.album)
+    }
+
     private fun metadata(mediaId: String, genre: String?) = MediaMetadataCache.Metadata(
         id = mediaId,
         title = "Title",

--- a/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/util/AppleSongMapperTest.kt
+++ b/app/src/test/java/io/github/proify/lyricon/amprovider/xposed/util/AppleSongMapperTest.kt
@@ -24,8 +24,10 @@ class AppleSongMapperTest {
         val mappedSong = AppleSongMapper.map(
             AppleSong(
                 genre = "J-Pop",
+                album = "超かぐや姫!",
                 originalTitle = "カワキヲアメク",
-                originalArtist = "美波"
+                originalArtist = "美波",
+                originalAlbum = "超かぐや姫!",
             )
         )
 
@@ -34,12 +36,20 @@ class AppleSongMapperTest {
             mappedSong.metadata?.getString(LyricMetadataKeys.APPLE_CATALOG_GENRE)
         )
         assertEquals(
+            "超かぐや姫!",
+            mappedSong.metadata?.getString(LyricMetadataKeys.APPLE_ALBUM)
+        )
+        assertEquals(
             "カワキヲアメク",
             mappedSong.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_TITLE)
         )
         assertEquals(
             "美波",
             mappedSong.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ARTIST)
+        )
+        assertEquals(
+            "超かぐや姫!",
+            mappedSong.metadata?.getString(LyricMetadataKeys.APPLE_ORIGINAL_ALBUM)
         )
     }
 


### PR DESCRIPTION
在使用模块时，有部分歌曲由于与q音及网易云存在**别名**等差异，导致只根据歌曲名并不能正常获取歌词，以下是我测试时使用的**示例歌曲**：

- Reply by KZ & Kaguya(cv.Yuko Natsuyoshi)
- Ex-otogibanashi by ryo (supercell)

这首歌曲存在别名的差异（这里可能是版权方或am的锅），在同专辑的其他歌曲如Ex-otogibanashi中却有ryo (supercell)与q音和网易云匹配从而可以通过作者匹配直接命中

但这还不够，只通过少量的信息匹配一首歌是否对应并不是正确的行为。

所以我们应该引入专辑进行检索，但这又带来了一个问题，Apple Music在日语专辑里面符号使用的是半角符号，而q音和网易云却使用的是全角符号，拿 **超かぐや姫!** 和 **超かぐや姫！** 对比，模块因为符号不等同导致视为两个专辑从而没有匹配上。

有了这些因素，我们将其作为一个渐进式的检索，按照以下顺序：

```text
1.歌名 + 歌手 + 专辑
2.歌名 + 歌手
3.歌名 + 拆分后的单个歌手/主创
4.歌名 + 专辑
5.仅歌名
```

这种做法显然更符合直觉且命中率高，但可能带来一些延迟，取决于歌曲与平台的差异程度。

然后对于原曲名，Apple Music的歌曲元信息往往是很完整的，因此引入了ISRC及轨道序号等因素进行匹配。

本人并不专业，只是将自己的见解表达出来，欢迎批评指正，也欢迎review代码。