### PR TITLE
feat(lyrics): add optional Apple Music lyrics blur animation

### DIFF
--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/common/RootConstants.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/common/RootConstants.kt
@@ -303,6 +303,8 @@ object RootConstants {
         "key_hook_apple_music_lunabeat_word_lyrics"
     const val KEY_HOOK_APPLE_MUSIC_LYRICS_BLUR_EFFECT =
         "key_hook_apple_music_lyrics_blur_effect"
+    const val KEY_HOOK_APPLE_MUSIC_LYRICS_BLUR_ANIMATION =
+        "key_hook_apple_music_lyrics_blur_animation"
     const val KEY_HOOK_APPLE_MUSIC_NATIVE_LYRICS_BLUR_MIN_RADIUS_DP =
         "key_hook_apple_music_native_lyrics_blur_min_radius_dp"
     const val KEY_HOOK_APPLE_MUSIC_NATIVE_LYRICS_BLUR_MAX_RADIUS_DP =
@@ -355,6 +357,7 @@ object RootConstants {
     const val APPLE_MUSIC_LYRICS_BLUR_EFFECT_ADVANCED_MATERIAL = 2
     const val DEFAULT_HOOK_APPLE_MUSIC_LYRICS_BLUR_EFFECT =
         APPLE_MUSIC_LYRICS_BLUR_EFFECT_OFF
+    const val DEFAULT_HOOK_APPLE_MUSIC_LYRICS_BLUR_ANIMATION = false
     const val DEFAULT_HOOK_APPLE_MUSIC_NATIVE_LYRICS_BLUR_MIN_RADIUS_DP = 3f
     const val DEFAULT_HOOK_APPLE_MUSIC_NATIVE_LYRICS_BLUR_MAX_RADIUS_DP = 6.5f
     const val MIN_HOOK_APPLE_MUSIC_NATIVE_LYRICS_BLUR_RADIUS_DP = 0f

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/ui/page/hooksettings/AppleMusicOptimizationPage.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/ui/page/hooksettings/AppleMusicOptimizationPage.kt
@@ -138,6 +138,14 @@ fun AppleMusicOptimizationPage(
             )
         )
     }
+    var lyricsBlurAnimation by remember {
+        mutableStateOf(
+            prefs.getBoolean(
+                RootConstants.KEY_HOOK_APPLE_MUSIC_LYRICS_BLUR_ANIMATION,
+                RootConstants.DEFAULT_HOOK_APPLE_MUSIC_LYRICS_BLUR_ANIMATION,
+            )
+        )
+    }
     val initialNativeLyricsBlurRadiusRange = remember(prefs) {
         val configuredMin = prefs.getFloat(
             RootConstants.KEY_HOOK_APPLE_MUSIC_NATIVE_LYRICS_BLUR_MIN_RADIUS_DP,
@@ -527,6 +535,22 @@ fun AppleMusicOptimizationPage(
                         onClick = { showLyricsBlurValuesDialog = true },
                     )
                 }
+                SwitchPreference(
+                    title = stringResource(
+                        R.string.title_apple_music_lyrics_blur_animation
+                    ),
+                    summary = stringResource(
+                        R.string.summary_apple_music_lyrics_blur_animation
+                    ),
+                    checked = lyricsBlurAnimation,
+                    onCheckedChange = { enabled ->
+                        lyricsBlurAnimation = enabled
+                        saveConfig(
+                            RootConstants.KEY_HOOK_APPLE_MUSIC_LYRICS_BLUR_ANIMATION,
+                            enabled,
+                        )
+                    },
+                )
                 SwitchPreference(
                     title = stringResource(
                         R.string.title_apple_music_follow_system_font_weight

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleMusicProviderOrchestrator.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleMusicProviderOrchestrator.kt
@@ -2064,6 +2064,7 @@ internal object AppleMusicProviderOrchestrator {
                     lyricsHooks.refreshAppleLyricsSupplementPresentation()
                 }
                 RootConstants.KEY_HOOK_APPLE_MUSIC_LYRICS_BLUR_EFFECT,
+                RootConstants.KEY_HOOK_APPLE_MUSIC_LYRICS_BLUR_ANIMATION,
                 RootConstants.KEY_HOOK_APPLE_MUSIC_NATIVE_LYRICS_BLUR_MIN_RADIUS_DP,
                 RootConstants.KEY_HOOK_APPLE_MUSIC_NATIVE_LYRICS_BLUR_MAX_RADIUS_DP,
                 RootConstants.KEY_HOOK_APPLE_MUSIC_ADVANCED_LYRICS_BLUR_MIN_RADIUS_PX,

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/AppleLyricsBlurHooks.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/AppleLyricsBlurHooks.kt
@@ -7,6 +7,8 @@
 package io.github.proify.lyricon.amprovider.xposed
 
 import android.annotation.SuppressLint
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
 import android.animation.ValueAnimator
 import android.app.Activity
 import android.app.Application
@@ -103,7 +105,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.math.abs
 import kotlin.math.roundToInt
-import android.content.SharedPreferences
 
 
 internal class AppleLyricsBlurHooks(
@@ -120,6 +121,7 @@ internal class AppleLyricsBlurHooks(
         const val APPLE_LYRICS_OUTGOING_RECHECK_DELAY_MS = 16L
         const val APPLE_LYRICS_BEFORE_FIRST_LINE_RECHECK_MAX_MS = 250L
         const val APPLE_LYRICS_HYPER_OS_SELF_BLUR_TYPE = 0
+        const val APPLE_LYRICS_BLUR_ANIMATION_DURATION_MS = 300L
     }
 
     private val application: Application
@@ -188,6 +190,13 @@ internal class AppleLyricsBlurHooks(
             RootConstants.DEFAULT_HOOK_APPLE_MUSIC_LYRICS_BLUR_EFFECT,
         ) ?: RootConstants.DEFAULT_HOOK_APPLE_MUSIC_LYRICS_BLUR_EFFECT
         return AppleLyricsBlurPolicy.normalizeMode(configured)
+    }
+    private fun appleLyricsBlurAnimationEnabled(): Boolean {
+        val prefs = contentUiLanguagePrefs
+        return prefs?.getBoolean(
+            RootConstants.KEY_HOOK_APPLE_MUSIC_LYRICS_BLUR_ANIMATION,
+            RootConstants.DEFAULT_HOOK_APPLE_MUSIC_LYRICS_BLUR_ANIMATION,
+        ) ?: RootConstants.DEFAULT_HOOK_APPLE_MUSIC_LYRICS_BLUR_ANIMATION
     }
 
     private fun appleLyricsBlurRadiusRange(mode: Int): ClosedFloatingPointRange<Float> {
@@ -1125,17 +1134,99 @@ internal class AppleLyricsBlurHooks(
 
     private fun applyAppleLyricsBlur(view: View, mode: Int, radiusPx: Int) {
         if (BuildConfig.DEBUG) {
-            ProviderLogger.debug("[LyricsScrollDiag] applyBlur: view=${view.javaClass.simpleName}@${System.identityHashCode(view)}, mode=$mode, radius=$radiusPx")
+            ProviderLogger.debug(
+                "[LyricsScrollDiag] applyBlur: " +
+                    "view=${view.javaClass.simpleName}@${System.identityHashCode(view)}, " +
+                    "mode=$mode, radius=$radiusPx"
+            )
+        }
+        if (mode == AppleLyricsBlurPolicy.OFF) {
+            clearAppleLyricsBlur(view)
+            return
+        }
+        val state = synchronized(appleLyricsBlurRuntimeStates) {
+            appleLyricsBlurRuntimeStates.getOrPut(view) {
+                AppleLyricsBlurRuntimeState()
+            }
         }
         appleLyricsBlurredViews.add(view)
+        if (state.blurMode != null && state.blurMode != mode) {
+            cancelAppleLyricsBlurAnimation(view, state, clearEffect = true)
+            state.blurMode = null
+        }
+        state.blurMode = mode
+        val targetRadius = radiusPx.coerceAtLeast(0).toFloat()
+        if (!appleLyricsBlurAnimationEnabled()) {
+            cancelAppleLyricsBlurAnimation(view, state, clearEffect = true)
+            state.currentBlurRadius = targetRadius
+            state.targetBlurRadius = targetRadius
+            applyAppleLyricsBlurRadius(view, mode, targetRadius)
+            return
+        }
+        animateAppleLyricsBlur(view, mode, targetRadius, state)
+    }
+
+    private fun animateAppleLyricsBlur(
+        view: View,
+        mode: Int,
+        targetRadius: Float,
+        state: AppleLyricsBlurRuntimeState,
+    ) {
+        if (
+            state.blurAnimator != null &&
+            state.blurMode == mode &&
+            state.targetBlurRadius == targetRadius
+        ) {
+            return
+        }
+        cancelAppleLyricsBlurAnimator(state)
+        val currentRadius = state.currentBlurRadius.coerceAtLeast(0f)
+        state.targetBlurRadius = targetRadius
+        if (currentRadius == targetRadius) {
+            applyAppleLyricsBlurRadius(view, mode, targetRadius)
+            return
+        }
+        val viewRef = WeakReference(view)
+        val animator = ValueAnimator.ofFloat(currentRadius, targetRadius).apply {
+            duration = APPLE_LYRICS_BLUR_ANIMATION_DURATION_MS
+            addUpdateListener { animation ->
+                if (state.blurAnimator !== animation) return@addUpdateListener
+                val targetView = viewRef.get() ?: return@addUpdateListener
+                val animatedRadius = animation.animatedValue as? Float ?: return@addUpdateListener
+                state.currentBlurRadius = animatedRadius
+                applyAppleLyricsBlurRadius(targetView, mode, animatedRadius)
+            }
+            addListener(object : AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: Animator) {
+                    if (state.blurAnimator !== animation) return
+                    state.blurAnimator = null
+                    state.currentBlurRadius = targetRadius
+                    state.targetBlurRadius = targetRadius
+                    viewRef.get()?.let { targetView ->
+                        applyAppleLyricsBlurRadius(targetView, mode, targetRadius)
+                    }
+                }
+            })
+        }
+        state.blurAnimator = animator
+        animator.start()
+    }
+
+    private fun applyAppleLyricsBlurRadius(view: View, mode: Int, radiusPx: Float) {
+        val boundedRadius = radiusPx.coerceAtLeast(0f)
+        if (boundedRadius <= 0f) {
+            view.setRenderEffect(null)
+            clearAppleLyricsHyperOsBlur(view)
+            return
+        }
         when (mode) {
             AppleLyricsBlurPolicy.NATIVE -> {
                 clearAppleLyricsHyperOsBlur(view)
-                applyAppleLyricsNativeBlur(view, radiusPx)
+                applyAppleLyricsNativeBlur(view, boundedRadius)
             }
             AppleLyricsBlurPolicy.ADVANCED_MATERIAL -> {
                 view.setRenderEffect(null)
-                if (!applyAppleLyricsHyperOsBlur(view, radiusPx)) {
+                if (!applyAppleLyricsHyperOsBlur(view, boundedRadius.roundToInt())) {
                     clearAppleLyricsBlur(view)
                 }
             }
@@ -1143,12 +1234,33 @@ internal class AppleLyricsBlurHooks(
         }
     }
 
-    private fun applyAppleLyricsNativeBlur(view: View, radiusPx: Int) {
+    private fun cancelAppleLyricsBlurAnimator(state: AppleLyricsBlurRuntimeState) {
+        val animator = state.blurAnimator ?: return
+        state.blurAnimator = null
+        animator.cancel()
+    }
+
+    private fun cancelAppleLyricsBlurAnimation(
+        view: View,
+        state: AppleLyricsBlurRuntimeState,
+        clearEffect: Boolean,
+    ) {
+        cancelAppleLyricsBlurAnimator(state)
+        if (clearEffect) {
+            view.setRenderEffect(null)
+            clearAppleLyricsHyperOsBlur(view)
+            state.currentBlurRadius = 0f
+            state.targetBlurRadius = 0f
+        }
+    }
+
+
+    private fun applyAppleLyricsNativeBlur(view: View, radiusPx: Float) {
         view.setRenderEffect(
-            radiusPx.takeIf { it > 0 }?.let { radius ->
+            radiusPx.takeIf { it > 0f }?.let { radius ->
                 RenderEffect.createBlurEffect(
-                    radius.toFloat(),
-                    radius.toFloat(),
+                    radius,
+                    radius,
                     Shader.TileMode.CLAMP,
                 )
             }
@@ -1169,10 +1281,28 @@ internal class AppleLyricsBlurHooks(
 
     private fun clearAppleLyricsBlur(view: View) {
         if (BuildConfig.DEBUG) {
-            ProviderLogger.debug("[LyricsScrollDiag] clearBlur: view=${view.javaClass.simpleName}@${System.identityHashCode(view)}")
+            ProviderLogger.debug(
+                "[LyricsScrollDiag] clearBlur: " +
+                    "view=${view.javaClass.simpleName}@${System.identityHashCode(view)}"
+            )
+        }
+        val state = synchronized(appleLyricsBlurRuntimeStates) {
+            appleLyricsBlurRuntimeStates[view]
+        }
+        state?.let {
+            cancelAppleLyricsBlurAnimator(it)
+            it.blurMode = null
+            it.currentBlurRadius = 0f
+            it.targetBlurRadius = 0f
         }
         view.setRenderEffect(null)
         clearAppleLyricsHyperOsBlur(view)
+        appleLyricsBlurredViews.remove(view)
+        synchronized(appleLyricsBlurRuntimeStates) {
+            if (state != null && appleLyricsBlurRuntimeStates[view] === state) {
+                appleLyricsBlurRuntimeStates.remove(view)
+            }
+        }
     }
 
     private fun clearAppleLyricsBlurForRecycler(recyclerView: View) {
@@ -1378,6 +1508,9 @@ internal class AppleLyricsBlurHooks(
                                 if (name == "setAdapter") {
                                     resetAppleLyricsBlurRuntimeState(recyclerView)
                                 } else {
+                                    if (name == "onChildAttachedToWindow") {
+                                        (chain.args.firstOrNull() as? View)?.let(::clearAppleLyricsBlur)
+                                    }
                                     if (name == "onLayout") {
                                         completeAppleLyricsProgrammaticRecenter(recyclerView)
                                     }

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/model/AppleLyricsBlurModels.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/model/AppleLyricsBlurModels.kt
@@ -6,6 +6,7 @@
 
 package io.github.proify.lyricon.amprovider.xposed
 
+import android.animation.ValueAnimator
 import java.lang.ref.WeakReference
 import java.lang.reflect.Method
 
@@ -25,4 +26,8 @@ internal data class AppleLyricsBlurRuntimeState(
     var outgoingZoneTopByPosition: Map<Int, Float> = emptyMap(),
     var pendingApplyBlur: Runnable? = null,
     var lastDiagnosticSignature: String? = null,
+    var blurMode: Int? = null,
+    var currentBlurRadius: Float = 0f,
+    var targetBlurRadius: Float = 0f,
+    var blurAnimator: ValueAnimator? = null,
 )

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -74,6 +74,8 @@
     <string name="title_apple_music_lyrics_blur_custom_values">Custom Blur Values</string>
     <string name="label_apple_music_lyrics_blur_min_value">Minimum (%1$s), default %2$s (range %3$s-%4$s)</string>
     <string name="label_apple_music_lyrics_blur_max_value">Maximum (%1$s), default %2$s (range %3$s-%4$s)</string>
+    <string name="title_apple_music_lyrics_blur_animation">Lyrics blur animation</string>
+    <string name="summary_apple_music_lyrics_blur_animation">Smoothly transition between blur states; may affect smoothness</string>
     <string name="title_apple_music_follow_system_font_weight">Follow system font weight</string>
     <string name="summary_apple_music_follow_system_font_weight">HyperOS only</string>
     <string name="title_apple_music_restore_cjk_original_metadata">Replace Chinese, Japanese, and Korean song information with original regional names</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,8 @@
     <string name="title_apple_music_lyrics_blur_custom_values">模糊值自定义</string>
     <string name="label_apple_music_lyrics_blur_min_value">最小值（%1$s），默认 %2$s（范围 %3$s-%4$s）</string>
     <string name="label_apple_music_lyrics_blur_max_value">最大值（%1$s），默认 %2$s（范围 %3$s-%4$s）</string>
+    <string name="title_apple_music_lyrics_blur_animation">歌词模糊动画</string>
+    <string name="summary_apple_music_lyrics_blur_animation">切换模糊状态时平滑过渡，可能影响流畅度</string>
     <string name="title_apple_music_follow_system_font_weight">跟随系统字体粗细</string>
     <string name="summary_apple_music_follow_system_font_weight">仅适配HyperOS</string>
     <string name="title_apple_music_restore_cjk_original_metadata">替换中日韩歌曲信息为原地区原名</string>


### PR DESCRIPTION
## 变更说明

为 Apple Music 歌词模糊效果增加可选的模糊半径过渡动画。

## 具体改动

- 新增“歌词模糊动画”设置，默认关闭。
- 切换歌词焦点时，模糊半径使用固定 300 ms 过渡动画。
- 支持 Android Native `RenderEffect` 和 HyperOS Advanced Material `setMiSelfBlur` 两种模糊后端。
- 动画目标变化时从当前模糊半径继续，避免视觉跳变。
- 防止旧动画结束回调覆盖新的模糊状态。
- 在关闭动画、切换模糊模式、RecyclerView 清理或复用、歌词滚动暂停，以及目标半径为零时，取消动画并清除残留模糊效果。
- 监听动画设置变化并立即刷新当前歌词模糊效果。
- 保持现有模糊半径计算、歌词滚动暂停、自动定位恢复以及 16/96 ms 调度逻辑不变。

## 验证情况

- `./gradlew :app:assembleDebug` 构建通过。
- XML 资源解析验证通过。
- 实机验证符合预期