### PR TITLE
feat(am): 支持 Apple Music 跟随系统字体

### DIFF
--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/common/RootConstants.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/common/RootConstants.kt
@@ -313,6 +313,8 @@ object RootConstants {
         "key_hook_apple_music_advanced_lyrics_blur_min_radius_px"
     const val KEY_HOOK_APPLE_MUSIC_ADVANCED_LYRICS_BLUR_MAX_RADIUS_PX =
         "key_hook_apple_music_advanced_lyrics_blur_max_radius_px"
+    const val KEY_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT =
+        "key_hook_apple_music_follow_system_font"
     const val KEY_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT_WEIGHT =
         "key_hook_apple_music_follow_system_font_weight"
     const val KEY_HOOK_AI_TRANS_ENABLE = "key_hook_ai_trans_enable"
@@ -366,6 +368,7 @@ object RootConstants {
     const val DEFAULT_HOOK_APPLE_MUSIC_ADVANCED_LYRICS_BLUR_MAX_RADIUS_PX = 26
     const val MIN_HOOK_APPLE_MUSIC_ADVANCED_LYRICS_BLUR_RADIUS_PX = 0
     const val MAX_HOOK_APPLE_MUSIC_ADVANCED_LYRICS_BLUR_RADIUS_PX = 100
+    const val DEFAULT_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT = false
     const val DEFAULT_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT_WEIGHT = false
     const val MIN_HOOK_LYRICON_PROVIDER_DELAY = -5000
     const val MAX_HOOK_LYRICON_PROVIDER_DELAY = 5000

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/common/lyric/AppleSystemFontWeightPolicy.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/common/lyric/AppleSystemFontWeightPolicy.kt
@@ -1,6 +1,16 @@
 package com.juren233.hyperlyricsenhanced.common.lyric
 
 object AppleSystemFontWeightPolicy {
+    enum class FontMode { ORIGINAL, APPLE_WEIGHT, SYSTEM }
+
+    // Settings remain independent; selecting a mode must never overwrite the saved flags.
+    fun fontMode(systemFont: Boolean, appleWeight: Boolean, text: CharSequence?): FontMode = when {
+        !shouldReplaceTextContent(text) -> FontMode.ORIGINAL
+        systemFont -> FontMode.SYSTEM
+        appleWeight -> FontMode.APPLE_WEIGHT
+        else -> FontMode.ORIGINAL
+    }
+
     private const val APPLE_MUSIC_PACKAGE = "com.apple.android.music"
     private const val FONT_RESOURCE_TYPE = "font"
     private const val REGULAR_WEIGHT = 400

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/ui/page/hooksettings/AppleMusicOptimizationPage.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/ui/page/hooksettings/AppleMusicOptimizationPage.kt
@@ -1,6 +1,10 @@
 package com.juren233.hyperlyricsenhanced.ui.page.hooksettings
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -11,6 +15,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -599,22 +604,28 @@ fun AppleMusicOptimizationPage(
                         )
                     },
                 )
-                SwitchPreference(
-                    title = stringResource(
-                        R.string.title_apple_music_follow_system_font_weight
-                    ),
-                    summary = stringResource(
-                        R.string.summary_apple_music_follow_system_font_weight
-                    ),
-                    checked = followSystemFontWeight,
-                    onCheckedChange = { enabled ->
-                        followSystemFontWeight = enabled
-                        saveConfig(
-                            RootConstants.KEY_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT_WEIGHT,
-                            enabled,
-                        )
-                    },
-                )
+                AnimatedVisibility(
+                    visible = !followSystemFont,
+                    enter = fadeIn() + expandVertically(expandFrom = Alignment.Top),
+                    exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Top),
+                ) {
+                    SwitchPreference(
+                        title = stringResource(
+                            R.string.title_apple_music_follow_system_font_weight
+                        ),
+                        summary = stringResource(
+                            R.string.summary_apple_music_follow_system_font_weight
+                        ),
+                        checked = followSystemFontWeight,
+                        onCheckedChange = { enabled ->
+                            followSystemFontWeight = enabled
+                            saveConfig(
+                                RootConstants.KEY_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT_WEIGHT,
+                                enabled,
+                            )
+                        },
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/juren233/hyperlyricsenhanced/ui/page/hooksettings/AppleMusicOptimizationPage.kt
+++ b/app/src/main/java/com/juren233/hyperlyricsenhanced/ui/page/hooksettings/AppleMusicOptimizationPage.kt
@@ -193,6 +193,14 @@ fun AppleMusicOptimizationPage(
         mutableIntStateOf(initialAdvancedLyricsBlurRadiusRange.second)
     }
     var showLyricsBlurValuesDialog by remember { mutableStateOf(false) }
+    var followSystemFont by remember {
+        mutableStateOf(
+            prefs.getBoolean(
+                RootConstants.KEY_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT,
+                RootConstants.DEFAULT_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT,
+            )
+        )
+    }
     var followSystemFontWeight by remember {
         mutableStateOf(
             prefs.getBoolean(
@@ -556,6 +564,22 @@ fun AppleMusicOptimizationPage(
                         },
                     )
                 }
+                SwitchPreference(
+                    title = stringResource(
+                        R.string.title_apple_music_follow_system_font
+                    ),
+                    summary = stringResource(
+                        R.string.summary_apple_music_follow_system_font
+                    ),
+                    checked = followSystemFont,
+                    onCheckedChange = { enabled ->
+                        followSystemFont = enabled
+                        saveConfig(
+                            RootConstants.KEY_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT,
+                            enabled,
+                        )
+                    },
+                )
                 SwitchPreference(
                     title = stringResource(
                         R.string.title_apple_music_follow_system_font_weight

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleMusicProviderOrchestrator.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/AppleMusicProviderOrchestrator.kt
@@ -2070,8 +2070,9 @@ internal object AppleMusicProviderOrchestrator {
                 RootConstants.KEY_HOOK_APPLE_MUSIC_ADVANCED_LYRICS_BLUR_MIN_RADIUS_PX,
                 RootConstants.KEY_HOOK_APPLE_MUSIC_ADVANCED_LYRICS_BLUR_MAX_RADIUS_PX ->
                     lyricsHooks.refreshAppleLyricsBlurEffect()
+                RootConstants.KEY_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT,
                 RootConstants.KEY_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT_WEIGHT ->
-                    lyricsHooks.refreshAppleSystemFontWeight()
+                    lyricsHooks.refreshAppleSystemFont()
                 RootConstants.KEY_HOOK_APPLE_MUSIC_VOLUME_BALANCE -> {
                     val enabled = changed.getBoolean(
                         key,

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/AppleLyricsSupplementHooks.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/AppleLyricsSupplementHooks.kt
@@ -3182,7 +3182,9 @@ internal class AppleLyricsSupplementHooks(
 
     fun refreshAppleLyricsBlurEffect() = blurHooks.refreshAppleLyricsBlurEffect()
 
-    fun refreshAppleSystemFontWeight() = systemFontHooks.refreshAppleSystemFontWeight()
+    fun refreshAppleSystemFont() = systemFontHooks.refreshAppleSystemFont()
+
+    fun refreshAppleSystemFontWeight() = refreshAppleSystemFont()
 
     private fun scheduleAppleLyricsBlur(
         recyclerView: Any?,

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/AppleSystemFontHooks.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/AppleSystemFontHooks.kt
@@ -204,36 +204,92 @@ internal class AppleSystemFontHooks(
         resolveHyperOsFontWeightMethods()
     }
 
+    private fun isFollowSystemFontEnabled(): Boolean =
+        contentUiLanguagePrefs?.getBoolean(
+            RootConstants.KEY_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT,
+            RootConstants.DEFAULT_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT,
+        ) == true
+
     private fun isFollowSystemFontWeightEnabled(): Boolean =
         contentUiLanguagePrefs?.getBoolean(
             RootConstants.KEY_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT_WEIGHT,
             RootConstants.DEFAULT_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT_WEIGHT,
         ) == true
 
-    fun refreshAppleSystemFontWeight() {
+    private fun createSystemDefaultTypeface(style: Int): Typeface =
+        Typeface.create(Typeface.DEFAULT, style)
+
+    private fun isAppleSystemTypeface(typeface: Typeface): Boolean =
+        originalAppleTypeface(typeface) != null
+
+    private fun resolveTextViewOriginalTypeface(
+        view: TextView,
+        requested: Typeface,
+    ): Typeface {
+        val state = synchronized(appleSystemFontTrackedTextViews) {
+            appleSystemFontTrackedTextViews[view]
+        }
+        if (state?.appliedTypeface === requested) {
+            return state.originalTypeface
+        }
+        return originalAppleTypeface(requested) ?: requested
+    }
+
+    private fun rememberTextViewState(
+        view: TextView,
+        originalTypeface: Typeface,
+        requestedWeight: Int,
+        italic: Boolean,
+        originalStyle: Int,
+        appliedTypeface: Typeface,
+    ) {
+        synchronized(appleSystemFontTrackedTextViews) {
+            appleSystemFontTrackedTextViews[view] = AppleSystemFontTextViewState(
+                originalTypeface = originalTypeface,
+                requestedWeight = requestedWeight,
+                italic = italic,
+                originalStyle = originalStyle,
+                appliedTypeface = appliedTypeface,
+            )
+        }
+    }
+
+    fun refreshAppleSystemFont() {
         mainHandler.post {
-            val enabled = isFollowSystemFontWeightEnabled()
+            val systemFontEnabled = isFollowSystemFontEnabled()
+            val systemFontWeightEnabled = isFollowSystemFontWeightEnabled()
             appleSystemFontVariationCache.clear()
-            if (enabled) currentMiuiFontWeightScale(forceRefresh = true)
+            if (systemFontWeightEnabled && !systemFontEnabled) {
+                currentMiuiFontWeightScale(forceRefresh = true)
+            }
             val trackedViews = synchronized(appleSystemFontTrackedTextViews) {
                 appleSystemFontTrackedTextViews.entries.map { it.key to it.value }
             }
             trackedViews.forEach { (view, state) ->
-                val target = if (enabled) {
-                    createAppleWeightAdjustedTypeface(
-                        original = state.originalTypeface,
-                        requestedWeight = state.requestedWeight,
-                        italic = state.italic,
-                        textView = view,
-                    )
-                } else {
-                    state.originalTypeface
+                val isAppleTypeface = isAppleSystemTypeface(state.originalTypeface)
+                val target = when {
+                    systemFontEnabled -> createSystemDefaultTypeface(state.originalStyle)
+                    systemFontWeightEnabled && isAppleTypeface ->
+                        createAppleWeightAdjustedTypeface(
+                            original = state.originalTypeface,
+                            requestedWeight = state.requestedWeight,
+                            italic = state.italic,
+                            textView = view,
+                        )
+                    else -> state.originalTypeface
                 }
-                appleSystemFontApplyGuard.run {
-                    if (enabled) {
-                        view.setTypeface(target)
-                    } else {
-                        view.setTypeface(target, state.originalStyle)
+                synchronized(appleSystemFontTrackedTextViews) {
+                    appleSystemFontTrackedTextViews[view] = state.copy(
+                        appliedTypeface = target,
+                    )
+                }
+                if (view.typeface !== target) {
+                    appleSystemFontApplyGuard.run {
+                        if (systemFontEnabled || systemFontWeightEnabled && isAppleTypeface) {
+                            view.setTypeface(target)
+                        } else {
+                            view.setTypeface(target, state.originalStyle)
+                        }
                     }
                 }
                 view.requestLayout()
@@ -241,12 +297,15 @@ internal class AppleSystemFontHooks(
             }
             if (BuildConfig.DEBUG) {
                 ProviderLogger.debug(
-                    "Apple 系统字体粗细已刷新：enabled=$enabled, " +
-                        "views=${trackedViews.size}, scale=${currentMiuiFontWeightScale()}"
+                    "Apple 系统字体已刷新：font=$systemFontEnabled, " +
+                        "weight=$systemFontWeightEnabled, views=${trackedViews.size}, " +
+                        "scale=${currentMiuiFontWeightScale()}"
                 )
             }
         }
     }
+
+    fun refreshAppleSystemFontWeight() = refreshAppleSystemFont()
 
 
     /**
@@ -267,7 +326,7 @@ internal class AppleSystemFontHooks(
                     ProviderLogger.info(
                         "Apple 系统字体粗细滑块已变化：scale=$scale, 重应用已跟踪视图"
                     )
-                    refreshAppleSystemFontWeight()
+                    refreshAppleSystemFont()
                 }
             }
             resolver.registerContentObserver(
@@ -327,6 +386,7 @@ internal class AppleSystemFontHooks(
             hookRegistrar.installResultOverrideHook(createWithWeight) { chain, originalResult ->
                 if (
                     appleSystemFontApplyGuard.isActive ||
+                    isFollowSystemFontEnabled() ||
                     !isFollowSystemFontWeightEnabled()
                 ) {
                     return@installResultOverrideHook originalResult
@@ -363,45 +423,15 @@ internal class AppleSystemFontHooks(
                 "setTypeface",
                 Typeface::class.java,
             ).apply { isAccessible = true }
-            hookRegistrar.installArgumentRewriteHook(setTypeface) { chain ->
-                if (appleSystemFontApplyGuard.isActive) {
-                    return@installArgumentRewriteHook null
-                }
-                val view = chain.thisObject as? TextView
-                    ?: return@installArgumentRewriteHook null
-                val requested = chain.args.firstOrNull() as? Typeface
-                    ?: return@installArgumentRewriteHook null
-                val originalTypeface = originalAppleTypeface(requested)
-                    ?: return@installArgumentRewriteHook null
-                synchronized(appleSystemFontTrackedTextViews) {
-                    appleSystemFontTrackedTextViews[view] =
-                        AppleSystemFontTextViewState(
-                            originalTypeface = originalTypeface,
-                            requestedWeight = originalTypeface.weight,
-                            italic = originalTypeface.isItalic,
-                            originalStyle = originalTypeface.style,
-                        )
-                }
-                if (!isFollowSystemFontWeightEnabled()) {
-                    return@installArgumentRewriteHook if (requested === originalTypeface) {
-                        null
-                    } else {
-                        arrayOf(originalTypeface)
-                    }
-                }
-                val replacement = createAppleWeightAdjustedTypeface(
-                    original = originalTypeface,
-                    textView = view,
-                )
-                logAppleSystemFontReplacement(
+            hookRegistrar.installHook(setTypeface, after = { chain, _ ->
+                val view = chain.thisObject as? TextView ?: return@installHook
+                handleTextViewTypefaceAfterSet(
+                    view = view,
+                    requested = chain.args.firstOrNull() as? Typeface,
+                    requestedStyle = null,
                     stage = "text_view",
-                    resourceName = null,
-                    original = originalTypeface,
-                    replacement = replacement,
-                    requestedWeight = originalTypeface.weight,
                 )
-                if (replacement === requested) null else arrayOf(replacement)
-            }
+            })
             installedHooks += "TextView.setTypeface"
         }.onFailure { throwable ->
             failedHooks += "TextView.setTypeface:${throwable.javaClass.simpleName}"
@@ -425,38 +455,62 @@ internal class AppleSystemFontHooks(
                     ?: return@installArgumentRewriteHook null
                 val requestedStyle = (chain.args.getOrNull(1) as? Number)?.toInt()
                     ?: Typeface.NORMAL
-                val originalTypeface = originalAppleTypeface(requested)
-                    ?: return@installArgumentRewriteHook null
+                val previousState = synchronized(appleSystemFontTrackedTextViews) {
+                    appleSystemFontTrackedTextViews[view]
+                }
+                val originalTypeface = resolveTextViewOriginalTypeface(view, requested)
+                val isAppleTypeface = isAppleSystemTypeface(originalTypeface)
+                val systemFontEnabled = isFollowSystemFontEnabled()
+                val systemFontWeightEnabled = isFollowSystemFontWeightEnabled()
+                if (!systemFontEnabled && !isAppleTypeface) {
+                    return@installArgumentRewriteHook null
+                }
+                val reusedState = previousState?.takeIf { it.appliedTypeface === requested }
                 val bold = requestedStyle and Typeface.BOLD != 0
-                val italic = originalTypeface.isItalic ||
-                    requestedStyle and Typeface.ITALIC != 0
-                val requestedWeight = if (bold) {
+                val italic = reusedState?.italic ?: (
+                    originalTypeface.isItalic ||
+                        requestedStyle and Typeface.ITALIC != 0
+                    )
+                val requestedWeight = reusedState?.requestedWeight ?: if (bold) {
                     maxOf(originalTypeface.weight, 700)
                 } else {
                     originalTypeface.weight
                 }
-                synchronized(appleSystemFontTrackedTextViews) {
-                    appleSystemFontTrackedTextViews[view] =
-                        AppleSystemFontTextViewState(
-                            originalTypeface = originalTypeface,
+                val replacement = when {
+                    systemFontEnabled -> createSystemDefaultTypeface(requestedStyle)
+                    systemFontWeightEnabled && isAppleTypeface ->
+                        createAppleWeightAdjustedTypeface(
+                            original = originalTypeface,
                             requestedWeight = requestedWeight,
                             italic = italic,
-                            originalStyle = requestedStyle,
+                            textView = view,
                         )
+                    else -> originalTypeface
                 }
-                if (!isFollowSystemFontWeightEnabled()) {
-                    return@installArgumentRewriteHook if (requested === originalTypeface) {
-                        null
-                    } else {
-                        arrayOf(originalTypeface, requestedStyle)
-                    }
-                }
-                val replacement = createAppleWeightAdjustedTypeface(
-                    original = originalTypeface,
+                rememberTextViewState(
+                    view = view,
+                    originalTypeface = originalTypeface,
                     requestedWeight = requestedWeight,
                     italic = italic,
-                    textView = view,
+                    originalStyle = requestedStyle,
+                    appliedTypeface = replacement,
                 )
+                if (!systemFontEnabled && !systemFontWeightEnabled) {
+                    return@installArgumentRewriteHook if (requested === replacement) {
+                        null
+                    } else {
+                        arrayOf(replacement, requestedStyle)
+                    }
+                }
+                if (systemFontEnabled) {
+                    return@installArgumentRewriteHook if (
+                        requested === replacement && requestedStyle == Typeface.NORMAL
+                    ) {
+                        null
+                    } else {
+                        arrayOf(replacement, Typeface.NORMAL)
+                    }
+                }
                 logAppleSystemFontReplacement(
                     stage = "custom_text_view_style",
                     resourceName = null,
@@ -631,6 +685,73 @@ internal class AppleSystemFontHooks(
             ProviderLogger.error(
                 "Apple 系统字体粗细 Hook 安装不完整：${failedHooks.joinToString()}"
             )
+        }
+    }
+
+    private fun handleTextViewTypefaceAfterSet(
+        view: TextView,
+        requested: Typeface?,
+        requestedStyle: Int?,
+        stage: String,
+    ) {
+        if (appleSystemFontApplyGuard.isActive) return
+        val current = view.typeface ?: return
+        val requestedTypeface = requested ?: current
+        val previousState = synchronized(appleSystemFontTrackedTextViews) {
+            appleSystemFontTrackedTextViews[view]
+        }
+        val reusedState = previousState?.takeIf { it.appliedTypeface === requestedTypeface }
+        val originalTypeface = reusedState?.originalTypeface
+            ?: originalAppleTypeface(requestedTypeface)
+            ?: requestedTypeface
+        val originalStyle = requestedStyle ?: reusedState?.originalStyle
+            ?: requestedTypeface.style
+        val systemFontEnabled = isFollowSystemFontEnabled()
+        val systemFontWeightEnabled = isFollowSystemFontWeightEnabled()
+        val isAppleTypeface = isAppleSystemTypeface(originalTypeface)
+        if (!systemFontEnabled && !isAppleTypeface && previousState == null) return
+        val italic = reusedState?.italic ?: (
+            originalTypeface.isItalic ||
+                originalStyle and Typeface.ITALIC != 0
+            )
+        val requestedWeight = reusedState?.requestedWeight ?: originalTypeface.weight
+        val target = when {
+            systemFontEnabled -> createSystemDefaultTypeface(originalStyle)
+            systemFontWeightEnabled && isAppleTypeface ->
+                createAppleWeightAdjustedTypeface(
+                    original = originalTypeface,
+                    requestedWeight = requestedWeight,
+                    italic = italic,
+                    textView = view,
+                )
+            else -> originalTypeface
+        }
+        rememberTextViewState(
+            view = view,
+            originalTypeface = originalTypeface,
+            requestedWeight = requestedWeight,
+            italic = italic,
+            originalStyle = originalStyle,
+            appliedTypeface = target,
+        )
+        if (current === target) return
+        appleSystemFontApplyGuard.run {
+            if (systemFontEnabled || systemFontWeightEnabled && isAppleTypeface) {
+                view.setTypeface(target)
+            } else {
+                view.setTypeface(target, originalStyle)
+            }
+        }
+        view.requestLayout()
+        view.invalidate()
+        if (BuildConfig.DEBUG && systemFontEnabled) {
+            val traceKey = "system_default_typeface:$stage:$originalStyle"
+            if (appleSystemFontDebugTraceKeys.add(traceKey)) {
+                ProviderLogger.debug(
+                    "Apple 系统默认字体替换：stage=$stage, style=$originalStyle, " +
+                        "views=${appleSystemFontTrackedTextViews.size}"
+                )
+            }
         }
     }
 
@@ -1168,6 +1289,9 @@ internal class AppleSystemFontHooks(
         textSizePx: Float,
     ): Typeface? {
         current ?: return null
+        if (isFollowSystemFontEnabled()) {
+            return createSystemDefaultTypeface(current.style)
+        }
         val request = appleSystemFontRequest(current) ?: return current
         if (
             !isFollowSystemFontWeightEnabled() ||
@@ -1284,7 +1408,7 @@ internal class AppleSystemFontHooks(
         }
         appleSystemFontManagedTypefaces.add(original)
         appleSystemFontResourceNameByTypeface[original] = resourceIdentity.third
-        if (!isFollowSystemFontWeightEnabled()) return original
+        if (isFollowSystemFontEnabled() || !isFollowSystemFontWeightEnabled()) return original
 
         val replacement = createAppleWeightAdjustedTypeface(original)
         logAppleSystemFontReplacement(
@@ -1919,94 +2043,87 @@ internal class AppleSystemFontHooks(
                 appleSystemFontOriginalTypefacesByReplacement[current]
             }
             val content = textOverride ?: view.text
-
-            fun restoreOriginalTypeface() {
-                val original = state?.originalTypeface ?: originalFromReplacement ?: return
-                view.setTypeface(original, state?.originalStyle ?: original.style)
-                if (requestLayout) view.requestLayout()
-            }
-
-            if (!isFollowSystemFontWeightEnabled()) {
-                if (originalFromReplacement != null) restoreOriginalTypeface()
-                if (state != null) {
-                    synchronized(appleSystemFontTrackedTextViews) {
-                        appleSystemFontTrackedTextViews.remove(view)
-                    }
-                }
-                return@run
-            }
-
-            if (!AppleSystemFontWeightPolicy.shouldReplaceTextContent(content)) {
-                if (originalFromReplacement != null) restoreOriginalTypeface()
-                synchronized(appleSystemFontTrackedTextViews) {
-                    appleSystemFontTrackedTextViews.remove(view)
-                }
-                return@run
-            }
-
+            val original = state?.originalTypeface
+                ?: originalFromReplacement
+                ?: current
+            val originalStyle = state?.originalStyle ?: original.style
+            val systemFontEnabled = isFollowSystemFontEnabled()
+            val systemFontWeightEnabled = isFollowSystemFontWeightEnabled()
+            val isAppleTypeface = isAppleSystemTypeface(original)
             val appliedSignature = synchronized(appleSystemFontSignaturesByReplacement) {
                 appleSystemFontSignaturesByReplacement[current]
             }
-            val original = originalFromReplacement
-                ?: if (state != null && current === state.originalTypeface) {
-                    state.originalTypeface
-                } else {
-                    current
-                }
-            val requestedWeight = if (state != null && state.originalTypeface === original) {
-                state.requestedWeight
-            } else {
-                appliedSignature?.semanticWeight ?: original.weight
-            }
-            val italic = if (state != null && state.originalTypeface === original) {
-                state.italic
-            } else {
-                appliedSignature?.italic ?: original.isItalic
-            }
-            val originalStyle = state?.originalStyle ?: original.style
-            val semanticWeight = AppleSystemFontWeightPolicy.semanticWeight(
-                reportedWeight = requestedWeight,
-                isBold = original.isBold,
-            )
-            val expectedWeight = mappedAppleSystemFontWeight(semanticWeight)
-            val expectedSignature = AppleSystemFontReplacementSignature(
-                effectiveSfProWeight = expectedWeight,
-                semanticWeight = semanticWeight,
-                usesCjkFallback = AppleSystemFontWeightPolicy.shouldUseSystemCjkFallback(content),
-                italic = italic,
-            )
-            val alreadyApplied = originalFromReplacement != null &&
-                appliedSignature == expectedSignature
-            if (alreadyApplied) return@run
-
-            val nextState = AppleSystemFontTextViewState(
-                originalTypeface = original,
-                requestedWeight = requestedWeight,
-                italic = italic,
-                originalStyle = originalStyle,
-            )
-            if (state != nextState) {
-                synchronized(appleSystemFontTrackedTextViews) {
-                    appleSystemFontTrackedTextViews[view] = nextState
+            val requestedWeight = state?.requestedWeight
+                ?: appliedSignature?.semanticWeight
+                ?: original.weight
+            val italic = state?.italic
+                ?: appliedSignature?.italic
+                ?: original.isItalic
+            val useAppleWeight = !systemFontEnabled &&
+                systemFontWeightEnabled &&
+                isAppleTypeface &&
+                AppleSystemFontWeightPolicy.shouldReplaceTextContent(content)
+            if (useAppleWeight && originalFromReplacement != null) {
+                val semanticWeight = AppleSystemFontWeightPolicy.semanticWeight(
+                    reportedWeight = requestedWeight,
+                    isBold = original.isBold,
+                )
+                val expectedSignature = AppleSystemFontReplacementSignature(
+                    effectiveSfProWeight = mappedAppleSystemFontWeight(semanticWeight),
+                    semanticWeight = semanticWeight,
+                    usesCjkFallback = AppleSystemFontWeightPolicy.shouldUseSystemCjkFallback(content),
+                    italic = italic,
+                )
+                if (appliedSignature == expectedSignature) {
+                    rememberTextViewState(
+                        view = view,
+                        originalTypeface = original,
+                        requestedWeight = requestedWeight,
+                        italic = italic,
+                        originalStyle = originalStyle,
+                        appliedTypeface = current,
+                    )
+                    return@run
                 }
             }
-
-            val replacement = createAppleWeightAdjustedTypeface(
-                original = original,
-                requestedWeight = requestedWeight,
-                italic = italic,
-                text = content,
-                textSizePx = view.textSize,
-            )
-            view.setTypeface(replacement)
+            val target = when {
+                systemFontEnabled -> createSystemDefaultTypeface(originalStyle)
+                useAppleWeight -> createAppleWeightAdjustedTypeface(
+                    original = original,
+                    requestedWeight = requestedWeight,
+                    italic = italic,
+                    text = content,
+                    textSizePx = view.textSize,
+                )
+                else -> original
+            }
+            if (systemFontEnabled || isAppleTypeface || state != null || originalFromReplacement != null) {
+                rememberTextViewState(
+                    view = view,
+                    originalTypeface = original,
+                    requestedWeight = requestedWeight,
+                    italic = italic,
+                    originalStyle = originalStyle,
+                    appliedTypeface = target,
+                )
+            }
+            if (current === target) return@run
+            if (systemFontEnabled || useAppleWeight) {
+                view.setTypeface(target)
+            } else {
+                view.setTypeface(target, originalStyle)
+            }
             if (requestLayout) view.requestLayout()
-            logAppleSystemFontReplacement(
-                stage = stage,
-                resourceName = null,
-                original = original,
-                replacement = replacement,
-                requestedWeight = requestedWeight,
-            )
+            view.invalidate()
+            if (useAppleWeight) {
+                logAppleSystemFontReplacement(
+                    stage = stage,
+                    resourceName = null,
+                    original = original,
+                    replacement = target,
+                    requestedWeight = requestedWeight,
+                )
+            }
         }
     }
 

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/AppleSystemFontHooks.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/AppleSystemFontHooks.kt
@@ -216,11 +216,51 @@ internal class AppleSystemFontHooks(
             RootConstants.DEFAULT_HOOK_APPLE_MUSIC_FOLLOW_SYSTEM_FONT_WEIGHT,
         ) == true
 
-    private fun createSystemDefaultTypeface(style: Int): Typeface =
-        Typeface.create(Typeface.DEFAULT, style)
+    private val systemDefaultTypefaceCache = ConcurrentHashMap<String, Typeface>()
 
-    private fun isAppleSystemTypeface(typeface: Typeface): Boolean =
-        originalAppleTypeface(typeface) != null
+    private fun createSystemDefaultTypeface(
+        requestedWeight: Int,
+        italic: Boolean,
+        textSizePx: Float?,
+    ): Typeface {
+        val weight = requestedWeight.coerceIn(1, 1000)
+        val methods = hyperOsFontWeightMethods
+        if (methods != null) {
+            @Suppress("DEPRECATION")
+            val density = application.resources.displayMetrics.scaledDensity
+            val textSizeSp = (textSizePx ?: 16f * density) / density.coerceAtLeast(0.01f)
+            // Reuse the binary-verified HyperOS mapping and font path already used by
+            // the CJK fallback. OEM axis values belong to this font, never to SF Pro.
+            val axis = hyperOsCjkWeightAxis(methods, weight, textSizeSp)
+            if (axis != null) {
+                val key = "${methods.miuiFontPath}:$weight:$axis:$italic"
+                systemDefaultTypefaceCache[key]?.let { return it }
+                val result = runCatching {
+                    val slant = if (italic) FontStyle.FONT_SLANT_ITALIC else FontStyle.FONT_SLANT_UPRIGHT
+                    val font = Font.Builder(File(methods.miuiFontPath))
+                        .setWeight(weight)
+                        .setSlant(slant)
+                        .setFontVariationSettings("'wght' $axis")
+                        .build()
+                    Typeface.CustomFallbackBuilder(FontFamily.Builder(font).build())
+                        .setSystemFallback("sans-serif")
+                        .setStyle(FontStyle(weight, slant))
+                        .build()
+                }.onFailure {
+                    logAppleFontDerivationFailure("system_default", it.toString())
+                }.getOrNull()
+                if (result != null) {
+                    if (systemDefaultTypefaceCache.size >= 128) systemDefaultTypefaceCache.clear()
+                    systemDefaultTypefaceCache[key] = result
+                    return result
+                }
+            }
+        }
+        val adjustment = application.resources.configuration.fontWeightAdjustment
+            .takeUnless { it == android.content.res.Configuration.FONT_WEIGHT_ADJUSTMENT_UNDEFINED }
+            ?: 0
+        return Typeface.create(Typeface.DEFAULT, (weight + adjustment).coerceIn(1, 1000), italic)
+    }
 
     private fun resolveTextViewOriginalTypeface(
         view: TextView,
@@ -259,41 +299,15 @@ internal class AppleSystemFontHooks(
             val systemFontEnabled = isFollowSystemFontEnabled()
             val systemFontWeightEnabled = isFollowSystemFontWeightEnabled()
             appleSystemFontVariationCache.clear()
-            if (systemFontWeightEnabled && !systemFontEnabled) {
+            systemDefaultTypefaceCache.clear()
+            if (systemFontWeightEnabled || systemFontEnabled) {
                 currentMiuiFontWeightScale(forceRefresh = true)
             }
             val trackedViews = synchronized(appleSystemFontTrackedTextViews) {
                 appleSystemFontTrackedTextViews.entries.map { it.key to it.value }
             }
-            trackedViews.forEach { (view, state) ->
-                val isAppleTypeface = isAppleSystemTypeface(state.originalTypeface)
-                val target = when {
-                    systemFontEnabled -> createSystemDefaultTypeface(state.originalStyle)
-                    systemFontWeightEnabled && isAppleTypeface ->
-                        createAppleWeightAdjustedTypeface(
-                            original = state.originalTypeface,
-                            requestedWeight = state.requestedWeight,
-                            italic = state.italic,
-                            textView = view,
-                        )
-                    else -> state.originalTypeface
-                }
-                synchronized(appleSystemFontTrackedTextViews) {
-                    appleSystemFontTrackedTextViews[view] = state.copy(
-                        appliedTypeface = target,
-                    )
-                }
-                if (view.typeface !== target) {
-                    appleSystemFontApplyGuard.run {
-                        if (systemFontEnabled || systemFontWeightEnabled && isAppleTypeface) {
-                            view.setTypeface(target)
-                        } else {
-                            view.setTypeface(target, state.originalStyle)
-                        }
-                    }
-                }
-                view.requestLayout()
-                view.invalidate()
+            trackedViews.forEach { (view, _) ->
+                applyAppleSystemFontForTextView(view, stage = "settings_refresh")
             }
             if (BuildConfig.DEBUG) {
                 ProviderLogger.debug(
@@ -318,7 +332,7 @@ internal class AppleSystemFontHooks(
             val resolver = application.contentResolver
             val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
                 override fun onChange(selfChange: Boolean, uri: Uri?) {
-                    if (!isFollowSystemFontWeightEnabled()) return
+                    if (!isFollowSystemFontEnabled() && !isFollowSystemFontWeightEnabled()) return
                     val scale = currentMiuiFontWeightScale(forceRefresh = true)
                     // 滑块写入 System/Global 两个命名空间会触发两次回调，按值去重。
                     if (scale == systemFontWeightObserverLastScale) return
@@ -459,13 +473,14 @@ internal class AppleSystemFontHooks(
                     appleSystemFontTrackedTextViews[view]
                 }
                 val originalTypeface = resolveTextViewOriginalTypeface(view, requested)
-                val isAppleTypeface = isAppleSystemTypeface(originalTypeface)
                 val systemFontEnabled = isFollowSystemFontEnabled()
                 val systemFontWeightEnabled = isFollowSystemFontWeightEnabled()
-                if (!systemFontEnabled && !isAppleTypeface) {
+                if (!AppleSystemFontWeightPolicy.shouldReplaceTextContent(view.text)) {
                     return@installArgumentRewriteHook null
                 }
-                val reusedState = previousState?.takeIf { it.appliedTypeface === requested }
+                val reusedState = previousState?.takeIf {
+                    it.appliedTypeface === requested && requestedStyle == Typeface.NORMAL
+                }
                 val bold = requestedStyle and Typeface.BOLD != 0
                 val italic = reusedState?.italic ?: (
                     originalTypeface.isItalic ||
@@ -477,8 +492,8 @@ internal class AppleSystemFontHooks(
                     originalTypeface.weight
                 }
                 val replacement = when {
-                    systemFontEnabled -> createSystemDefaultTypeface(requestedStyle)
-                    systemFontWeightEnabled && isAppleTypeface ->
+                    systemFontEnabled -> createSystemDefaultTypeface(requestedWeight, italic, view.textSize)
+                    systemFontWeightEnabled ->
                         createAppleWeightAdjustedTypeface(
                             original = originalTypeface,
                             requestedWeight = requestedWeight,
@@ -492,7 +507,7 @@ internal class AppleSystemFontHooks(
                     originalTypeface = originalTypeface,
                     requestedWeight = requestedWeight,
                     italic = italic,
-                    originalStyle = requestedStyle,
+                    originalStyle = reusedState?.originalStyle ?: requestedStyle,
                     appliedTypeface = replacement,
                 )
                 if (!systemFontEnabled && !systemFontWeightEnabled) {
@@ -706,53 +721,14 @@ internal class AppleSystemFontHooks(
             ?: requestedTypeface
         val originalStyle = requestedStyle ?: reusedState?.originalStyle
             ?: requestedTypeface.style
-        val systemFontEnabled = isFollowSystemFontEnabled()
-        val systemFontWeightEnabled = isFollowSystemFontWeightEnabled()
-        val isAppleTypeface = isAppleSystemTypeface(originalTypeface)
-        if (!systemFontEnabled && !isAppleTypeface && previousState == null) return
         val italic = reusedState?.italic ?: (
-            originalTypeface.isItalic ||
-                originalStyle and Typeface.ITALIC != 0
-            )
-        val requestedWeight = reusedState?.requestedWeight ?: originalTypeface.weight
-        val target = when {
-            systemFontEnabled -> createSystemDefaultTypeface(originalStyle)
-            systemFontWeightEnabled && isAppleTypeface ->
-                createAppleWeightAdjustedTypeface(
-                    original = originalTypeface,
-                    requestedWeight = requestedWeight,
-                    italic = italic,
-                    textView = view,
-                )
-            else -> originalTypeface
-        }
-        rememberTextViewState(
-            view = view,
-            originalTypeface = originalTypeface,
-            requestedWeight = requestedWeight,
-            italic = italic,
-            originalStyle = originalStyle,
-            appliedTypeface = target,
+            originalTypeface.isItalic || originalStyle and Typeface.ITALIC != 0
         )
-        if (current === target) return
-        appleSystemFontApplyGuard.run {
-            if (systemFontEnabled || systemFontWeightEnabled && isAppleTypeface) {
-                view.setTypeface(target)
-            } else {
-                view.setTypeface(target, originalStyle)
-            }
-        }
-        view.requestLayout()
-        view.invalidate()
-        if (BuildConfig.DEBUG && systemFontEnabled) {
-            val traceKey = "system_default_typeface:$stage:$originalStyle"
-            if (appleSystemFontDebugTraceKeys.add(traceKey)) {
-                ProviderLogger.debug(
-                    "Apple 系统默认字体替换：stage=$stage, style=$originalStyle, " +
-                        "views=${appleSystemFontTrackedTextViews.size}"
-                )
-            }
-        }
+        val requestedWeight = reusedState?.requestedWeight ?: originalTypeface.weight
+        rememberTextViewState(
+            view, originalTypeface, requestedWeight, italic, originalStyle, current,
+        )
+        applyAppleSystemFontForTextView(view, stage = stage)
     }
 
     private fun hookAppleComposeSystemFontWeight(
@@ -1289,8 +1265,14 @@ internal class AppleSystemFontHooks(
         textSizePx: Float,
     ): Typeface? {
         current ?: return null
+        if (!AppleSystemFontWeightPolicy.shouldReplaceTextContent(text)) return current
         if (isFollowSystemFontEnabled()) {
-            return createSystemDefaultTypeface(current.style)
+            val request = appleSystemFontRequest(current)
+            return createSystemDefaultTypeface(
+                request?.semanticWeight ?: current.weight,
+                request?.italic ?: current.isItalic,
+                textSizePx,
+            )
         }
         val request = appleSystemFontRequest(current) ?: return current
         if (
@@ -1995,7 +1977,7 @@ internal class AppleSystemFontHooks(
         )
 
     private fun logAppleSystemFontDrawState(view: TextView) {
-        if (!BuildConfig.DEBUG || !isFollowSystemFontWeightEnabled()) return
+        if (!BuildConfig.DEBUG || (!isFollowSystemFontEnabled() && !isFollowSystemFontWeightEnabled())) return
         val viewTypeface = view.typeface
         val paint = view.paint
         val paintTypeface = paint.typeface
@@ -2043,26 +2025,27 @@ internal class AppleSystemFontHooks(
                 appleSystemFontOriginalTypefacesByReplacement[current]
             }
             val content = textOverride ?: view.text
-            val original = state?.originalTypeface
-                ?: originalFromReplacement
-                ?: current
-            val originalStyle = state?.originalStyle ?: original.style
+            val activeState = state?.takeIf {
+                current === it.appliedTypeface || current === it.originalTypeface
+            }
+            val original = originalFromReplacement ?: activeState?.originalTypeface ?: current
+            val originalStyle = activeState?.originalStyle ?: original.style
             val systemFontEnabled = isFollowSystemFontEnabled()
             val systemFontWeightEnabled = isFollowSystemFontWeightEnabled()
-            val isAppleTypeface = isAppleSystemTypeface(original)
             val appliedSignature = synchronized(appleSystemFontSignaturesByReplacement) {
                 appleSystemFontSignaturesByReplacement[current]
             }
-            val requestedWeight = state?.requestedWeight
+            val requestedWeight = activeState?.requestedWeight
                 ?: appliedSignature?.semanticWeight
                 ?: original.weight
-            val italic = state?.italic
+            val italic = activeState?.italic
                 ?: appliedSignature?.italic
                 ?: original.isItalic
-            val useAppleWeight = !systemFontEnabled &&
-                systemFontWeightEnabled &&
-                isAppleTypeface &&
-                AppleSystemFontWeightPolicy.shouldReplaceTextContent(content)
+            val mode = AppleSystemFontWeightPolicy.fontMode(
+                systemFontEnabled, systemFontWeightEnabled, content,
+            )
+            val useSystemFont = mode == AppleSystemFontWeightPolicy.FontMode.SYSTEM
+            val useAppleWeight = mode == AppleSystemFontWeightPolicy.FontMode.APPLE_WEIGHT
             if (useAppleWeight && originalFromReplacement != null) {
                 val semanticWeight = AppleSystemFontWeightPolicy.semanticWeight(
                     reportedWeight = requestedWeight,
@@ -2087,7 +2070,7 @@ internal class AppleSystemFontHooks(
                 }
             }
             val target = when {
-                systemFontEnabled -> createSystemDefaultTypeface(originalStyle)
+                useSystemFont -> createSystemDefaultTypeface(requestedWeight, italic, view.textSize)
                 useAppleWeight -> createAppleWeightAdjustedTypeface(
                     original = original,
                     requestedWeight = requestedWeight,
@@ -2097,7 +2080,7 @@ internal class AppleSystemFontHooks(
                 )
                 else -> original
             }
-            if (systemFontEnabled || isAppleTypeface || state != null || originalFromReplacement != null) {
+            if (AppleSystemFontWeightPolicy.shouldReplaceTextContent(content) || state != null || originalFromReplacement != null) {
                 rememberTextViewState(
                     view = view,
                     originalTypeface = original,
@@ -2108,14 +2091,14 @@ internal class AppleSystemFontHooks(
                 )
             }
             if (current === target) return@run
-            if (systemFontEnabled || useAppleWeight) {
+            if (useSystemFont || useAppleWeight) {
                 view.setTypeface(target)
             } else {
                 view.setTypeface(target, originalStyle)
             }
             if (requestLayout) view.requestLayout()
             view.invalidate()
-            if (useAppleWeight) {
+            if (useAppleWeight || useSystemFont) {
                 logAppleSystemFontReplacement(
                     stage = stage,
                     resourceName = null,

--- a/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/model/AppleSystemFontModels.kt
+++ b/app/src/main/java/io/github/proify/lyricon/amprovider/xposed/lyrics/model/AppleSystemFontModels.kt
@@ -18,6 +18,7 @@ internal data class AppleSystemFontTextViewState(
     val requestedWeight: Int,
     val italic: Boolean,
     val originalStyle: Int,
+    val appliedTypeface: Typeface? = null,
 )
 
 internal data class AppleSystemFontTemplateFieldPath(

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -78,7 +78,7 @@
     <string name="title_apple_music_lyrics_blur_animation">Lyrics blur animation</string>
     <string name="summary_apple_music_lyrics_blur_animation">Smoothly transition between blur states; may affect smoothness</string>
     <string name="title_apple_music_follow_system_font">Follow system font</string>
-    <string name="summary_apple_music_follow_system_font">Remove Apple Music custom fonts and use the system default font</string>
+    <string name="summary_apple_music_follow_system_font">Also follow system font weight when enabled</string>
     <string name="title_apple_music_follow_system_font_weight">Follow system font weight</string>
     <string name="summary_apple_music_follow_system_font_weight">HyperOS only</string>
     <string name="title_apple_music_restore_cjk_original_metadata">Replace Chinese, Japanese, and Korean song information with original regional names</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -77,6 +77,8 @@
     <string name="label_apple_music_lyrics_blur_max_value">Maximum (%1$s), default %2$s (range %3$s-%4$s)</string>
     <string name="title_apple_music_lyrics_blur_animation">Lyrics blur animation</string>
     <string name="summary_apple_music_lyrics_blur_animation">Smoothly transition between blur states; may affect smoothness</string>
+    <string name="title_apple_music_follow_system_font">Follow system font</string>
+    <string name="summary_apple_music_follow_system_font">Remove Apple Music custom fonts and use the system default font</string>
     <string name="title_apple_music_follow_system_font_weight">Follow system font weight</string>
     <string name="summary_apple_music_follow_system_font_weight">HyperOS only</string>
     <string name="title_apple_music_restore_cjk_original_metadata">Replace Chinese, Japanese, and Korean song information with original regional names</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,7 +79,7 @@
     <string name="title_apple_music_lyrics_blur_animation">歌词模糊动画</string>
     <string name="summary_apple_music_lyrics_blur_animation">切换模糊状态时平滑过渡，可能影响流畅度</string>
     <string name="title_apple_music_follow_system_font">跟随系统字体</string>
-    <string name="summary_apple_music_follow_system_font">去除 Apple Music 自定义字体，使用系统默认字体</string>
+    <string name="summary_apple_music_follow_system_font">开启后同步跟随粗细</string>
     <string name="title_apple_music_follow_system_font_weight">跟随系统字体粗细</string>
     <string name="summary_apple_music_follow_system_font_weight">仅适配HyperOS</string>
     <string name="title_apple_music_restore_cjk_original_metadata">替换中日韩歌曲信息为原地区原名</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,8 @@
     <string name="label_apple_music_lyrics_blur_max_value">最大值（%1$s），默认 %2$s（范围 %3$s-%4$s）</string>
     <string name="title_apple_music_lyrics_blur_animation">歌词模糊动画</string>
     <string name="summary_apple_music_lyrics_blur_animation">切换模糊状态时平滑过渡，可能影响流畅度</string>
+    <string name="title_apple_music_follow_system_font">跟随系统字体</string>
+    <string name="summary_apple_music_follow_system_font">去除 Apple Music 自定义字体，使用系统默认字体</string>
     <string name="title_apple_music_follow_system_font_weight">跟随系统字体粗细</string>
     <string name="summary_apple_music_follow_system_font_weight">仅适配HyperOS</string>
     <string name="title_apple_music_restore_cjk_original_metadata">替换中日韩歌曲信息为原地区原名</string>

--- a/app/src/test/java/com/juren233/hyperlyricsenhanced/common/lyric/AppleSystemFontWeightPolicyTest.kt
+++ b/app/src/test/java/com/juren233/hyperlyricsenhanced/common/lyric/AppleSystemFontWeightPolicyTest.kt
@@ -7,6 +7,44 @@ import org.junit.Test
 
 class AppleSystemFontWeightPolicyTest {
     @Test
+    fun `system font takes priority without depending on the saved weight toggle`() {
+        assertEquals(AppleSystemFontWeightPolicy.FontMode.ORIGINAL, AppleSystemFontWeightPolicy.fontMode(false, false, "歌词 Lyrics"))
+        assertEquals(AppleSystemFontWeightPolicy.FontMode.APPLE_WEIGHT, AppleSystemFontWeightPolicy.fontMode(false, true, "歌词 Lyrics"))
+        assertEquals(AppleSystemFontWeightPolicy.FontMode.SYSTEM, AppleSystemFontWeightPolicy.fontMode(true, false, "歌词 Lyrics"))
+        assertEquals(AppleSystemFontWeightPolicy.FontMode.SYSTEM, AppleSystemFontWeightPolicy.fontMode(true, true, "歌词 Lyrics"))
+    }
+
+    @Test
+    fun `icon only content stays original in all modes including after recycling text`() {
+        for (systemFont in listOf(false, true)) {
+            for (appleWeight in listOf(false, true)) {
+                for (text in listOf(null, "", " ", "\uE001\uF8FF", "♫")) {
+                    assertEquals(
+                        AppleSystemFontWeightPolicy.FontMode.ORIGINAL,
+                        AppleSystemFontWeightPolicy.fontMode(systemFont, appleWeight, text),
+                    )
+                }
+            }
+        }
+        assertEquals(
+            AppleSystemFontWeightPolicy.FontMode.SYSTEM,
+            AppleSystemFontWeightPolicy.fontMode(true, false, "下一首"),
+        )
+    }
+
+    @Test
+    fun `leaving system mode resumes either saved weight setting`() {
+        for (savedWeight in listOf(false, true)) {
+            val before = AppleSystemFontWeightPolicy.fontMode(false, savedWeight, "Apple Music")
+            assertEquals(
+                AppleSystemFontWeightPolicy.FontMode.SYSTEM,
+                AppleSystemFontWeightPolicy.fontMode(true, savedWeight, "Apple Music"),
+            )
+            assertEquals(before, AppleSystemFontWeightPolicy.fontMode(false, savedWeight, "Apple Music"))
+        }
+    }
+
+    @Test
     fun `replaces only Apple Music primary text font resources`() {
         listOf("regular", "medium", "semibold", "bold", "black").forEach { resourceName ->
             assertTrue(


### PR DESCRIPTION
## 功能说明

新增 Apple Music「跟随系统字体」，目标分支为 `7.6.0`。复用现有字体 Hook、偏好同步和重入保护。

- 两个字体开关均默认关闭，保留已有用户保存的字重设置。
- 开启「跟随系统字体」后，使用系统字体并同步跟随粗细；副标题为「开启后同步跟随粗细」。旧的「跟随系统字体粗细」开关按现有淡入展开/淡出收起动画隐藏，旧 Apple 字重处理停止生效。
- 关闭新开关后，重新显示旧开关并恢复其保存状态，不重置用户偏好。
- 系统字体模式独立监听 HyperOS 粗细变化，复用现有系统字体路径和 OEM 字重映射，不依赖隐藏的旧开关。
- 保留普通 TextView 的字重处理范围，避免只处理预先登记的字体；保护纯图标文本及 Compose 中的图标字体片段，并处理原字体恢复。

保留 MUKAPP 的原始功能提交，后续修复由维护者追加。

## 验证

- 12 项 `AppleSystemFontWeightPolicyTest` 定向测试通过。
- Release Kotlin 编译及 `git diff --check` 通过。
- 维护者已安装测试并反馈「没问题」。该反馈覆盖实际测试场景，不扩展为所有系统版本、主题字体或 Compose 即时刷新场景均已验证。
